### PR TITLE
make api threadsafe

### DIFF
--- a/lib/constantcontact/services/account_service.rb
+++ b/lib/constantcontact/services/account_service.rb
@@ -7,33 +7,31 @@
 module ConstantContact
   module Services
     class AccountService < BaseService
-      class << self
 
-        # Get a summary of account information
-        # @return [AccountInfo]
-        def get_account_info()
-          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.account_info')
-          url = build_url(url)
-          response = RestClient.get(url, get_headers())
-          Components::AccountInfo.create(JSON.parse(response.body))
-        end
-
-
-        # Get all verified email addresses associated with an account
-        # @param [Hash] params - hash of query parameters/values to append to the request
-        # @return [Array<VerifiedEmailAddress>]
-        def get_verified_email_addresses(params)
-          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.account_verified_addresses')
-          url = build_url(url, params)
-          response = RestClient.get(url, get_headers())
-          email_addresses = []
-          JSON.parse(response.body).each do |email_address|
-            email_addresses << Components::VerifiedEmailAddress.create(email_address)
-          end
-          email_addresses
-        end
-
+      # Get a summary of account information
+      # @return [AccountInfo]
+      def get_account_info()
+        url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.account_info')
+        url = build_url(url)
+        response = RestClient.get(url, get_headers())
+        Components::AccountInfo.create(JSON.parse(response.body))
       end
+
+
+      # Get all verified email addresses associated with an account
+      # @param [Hash] params - hash of query parameters/values to append to the request
+      # @return [Array<VerifiedEmailAddress>]
+      def get_verified_email_addresses(params)
+        url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.account_verified_addresses')
+        url = build_url(url, params)
+        response = RestClient.get(url, get_headers())
+        email_addresses = []
+        JSON.parse(response.body).each do |email_address|
+          email_addresses << Components::VerifiedEmailAddress.create(email_address)
+        end
+        email_addresses
+      end
+
     end
   end
 end

--- a/lib/constantcontact/services/activity_service.rb
+++ b/lib/constantcontact/services/activity_service.rb
@@ -7,130 +7,128 @@
 module ConstantContact
   module Services
     class ActivityService < BaseService
-      class << self
 
-        # Get a set of activities
-        # @param [Hash] params - query parameters to be appended to the url
-        # @return [Array<Activity>]
-        def get_activities(params = {})
-          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.activities')
-          url = build_url(url, params)
-          response = RestClient.get(url, get_headers())
+      # Get a set of activities
+      # @param [Hash] params - query parameters to be appended to the url
+      # @return [Array<Activity>]
+      def get_activities(params = {})
+        url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.activities')
+        url = build_url(url, params)
+        response = RestClient.get(url, get_headers())
 
-          activities = []
-          JSON.parse(response.body).each do |activity|
-            activities << Components::Activity.create(activity)
-          end
-
-          activities
+        activities = []
+        JSON.parse(response.body).each do |activity|
+          activities << Components::Activity.create(activity)
         end
 
-
-        # Get an array of activities
-        # @param [String] activity_id - Activity id
-        # @return [Activity]
-        def get_activity(activity_id)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.activity'), activity_id)
-          url = build_url(url)
-          response = RestClient.get(url, get_headers())
-          Components::Activity.create(JSON.parse(response.body))
-        end
-
-
-        # Create an Add Contacts Activity
-        # @param [AddContacts] add_contacts
-        # @return [Activity]
-        def create_add_contacts_activity(add_contacts)
-          url = Util::Config.get('endpoints.base_url') +
-                Util::Config.get('endpoints.add_contacts_activity')
-          url = build_url(url)
-          payload = add_contacts.to_json
-          response = RestClient.post(url, payload, get_headers())
-          Components::Activity.create(JSON.parse(response.body))
-        end
-
-
-        # Create an Add Contacts Activity from a file. Valid file types are txt, csv, xls, xlsx
-        # @param [String] file_name - The name of the file (ie: contacts.csv)
-        # @param [String] contents - The content of the file
-        # @param [String] lists - Comma separated list of ContactList id's to add the contacts to
-        # @return [Activity]
-        def create_add_contacts_activity_from_file(file_name, contents, lists)
-          url = Util::Config.get('endpoints.base_url') +
-                Util::Config.get('endpoints.add_contacts_activity')
-          url = build_url(url)
-
-          payload = { :file_name => file_name, :lists => lists, :data => contents, :multipart => true }
-
-          response = RestClient.post(url, payload, get_headers())
-          Components::Activity.create(JSON.parse(response.body))
-        end
-
-
-        # Create a Clear Lists Activity
-        # @param [Array<lists>] lists - array of list id's to be cleared
-        # @return [Activity]
-        def add_clear_lists_activity(lists)
-          url = Util::Config.get('endpoints.base_url') +
-                Util::Config.get('endpoints.clear_lists_activity')
-          url = build_url(url)
-          payload = {'lists' => lists}.to_json
-          response = RestClient.post(url, payload, get_headers())
-          Components::Activity.create(JSON.parse(response.body))
-        end
-
-
-        # Create an Export Contacts Activity
-        # @param [ExportContacts] export_contacts
-        # @return [Activity]
-        def add_export_contacts_activity(export_contacts)
-          url = Util::Config.get('endpoints.base_url') +
-                Util::Config.get('endpoints.export_contacts_activity')
-          url = build_url(url)
-          payload = export_contacts.to_json
-          response = RestClient.post(url, payload, get_headers())
-          Components::Activity.create(JSON.parse(response.body))
-        end
-
-
-        # Create a Remove Contacts From Lists Activity
-        # @param [<Array>EmailAddress] email_addresses
-        # @param [<Array>RemoveFromLists] lists
-        # @return [Activity]
-        def add_remove_contacts_from_lists_activity(email_addresses, lists)
-          url = Util::Config.get('endpoints.base_url') +
-                Util::Config.get('endpoints.remove_from_lists_activity')
-          url = build_url(url)
-
-          payload = { 'import_data' => [], 'lists' => lists }
-          email_addresses.each do |email_address|
-            payload['import_data'] << { 'email_addresses' => [email_address] }
-          end
-          payload = payload.to_json
-
-          response = RestClient.post(url, payload, get_headers())
-          Components::Activity.create(JSON.parse(response.body))
-        end
-
-
-        # Create an Remove Contacts Activity from a file. Valid file types are txt, csv, xls, xlsx
-        # @param [String] file_name - The name of the file (ie: contacts.csv)
-        # @param [String] contents - The content of the file
-        # @param [String] lists - Comma separated list of ContactList id' to add the contacts too
-        # @return [Activity]
-        def add_remove_contacts_from_lists_activity_from_file(file_name, contents, lists)
-          url = Util::Config.get('endpoints.base_url') +
-                Util::Config.get('endpoints.remove_from_lists_activity')
-          url = build_url(url)
-
-          payload = { :file_name => file_name, :lists => lists, :data => contents, :multipart => true }
-
-          response = RestClient.post(url, payload, get_headers())
-          Components::Activity.create(JSON.parse(response.body))
-        end
-
+        activities
       end
+
+
+      # Get an array of activities
+      # @param [String] activity_id - Activity id
+      # @return [Activity]
+      def get_activity(activity_id)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.activity'), activity_id)
+        url = build_url(url)
+        response = RestClient.get(url, get_headers())
+        Components::Activity.create(JSON.parse(response.body))
+      end
+
+
+      # Create an Add Contacts Activity
+      # @param [AddContacts] add_contacts
+      # @return [Activity]
+      def create_add_contacts_activity(add_contacts)
+        url = Util::Config.get('endpoints.base_url') +
+              Util::Config.get('endpoints.add_contacts_activity')
+        url = build_url(url)
+        payload = add_contacts.to_json
+        response = RestClient.post(url, payload, get_headers())
+        Components::Activity.create(JSON.parse(response.body))
+      end
+
+
+      # Create an Add Contacts Activity from a file. Valid file types are txt, csv, xls, xlsx
+      # @param [String] file_name - The name of the file (ie: contacts.csv)
+      # @param [String] contents - The content of the file
+      # @param [String] lists - Comma separated list of ContactList id's to add the contacts to
+      # @return [Activity]
+      def create_add_contacts_activity_from_file(file_name, contents, lists)
+        url = Util::Config.get('endpoints.base_url') +
+              Util::Config.get('endpoints.add_contacts_activity')
+        url = build_url(url)
+
+        payload = { :file_name => file_name, :lists => lists, :data => contents, :multipart => true }
+
+        response = RestClient.post(url, payload, get_headers())
+        Components::Activity.create(JSON.parse(response.body))
+      end
+
+
+      # Create a Clear Lists Activity
+      # @param [Array<lists>] lists - array of list id's to be cleared
+      # @return [Activity]
+      def add_clear_lists_activity(lists)
+        url = Util::Config.get('endpoints.base_url') +
+              Util::Config.get('endpoints.clear_lists_activity')
+        url = build_url(url)
+        payload = {'lists' => lists}.to_json
+        response = RestClient.post(url, payload, get_headers())
+        Components::Activity.create(JSON.parse(response.body))
+      end
+
+
+      # Create an Export Contacts Activity
+      # @param [ExportContacts] export_contacts
+      # @return [Activity]
+      def add_export_contacts_activity(export_contacts)
+        url = Util::Config.get('endpoints.base_url') +
+              Util::Config.get('endpoints.export_contacts_activity')
+        url = build_url(url)
+        payload = export_contacts.to_json
+        response = RestClient.post(url, payload, get_headers())
+        Components::Activity.create(JSON.parse(response.body))
+      end
+
+
+      # Create a Remove Contacts From Lists Activity
+      # @param [<Array>EmailAddress] email_addresses
+      # @param [<Array>RemoveFromLists] lists
+      # @return [Activity]
+      def add_remove_contacts_from_lists_activity(email_addresses, lists)
+        url = Util::Config.get('endpoints.base_url') +
+              Util::Config.get('endpoints.remove_from_lists_activity')
+        url = build_url(url)
+
+        payload = { 'import_data' => [], 'lists' => lists }
+        email_addresses.each do |email_address|
+          payload['import_data'] << { 'email_addresses' => [email_address] }
+        end
+        payload = payload.to_json
+
+        response = RestClient.post(url, payload, get_headers())
+        Components::Activity.create(JSON.parse(response.body))
+      end
+
+
+      # Create an Remove Contacts Activity from a file. Valid file types are txt, csv, xls, xlsx
+      # @param [String] file_name - The name of the file (ie: contacts.csv)
+      # @param [String] contents - The content of the file
+      # @param [String] lists - Comma separated list of ContactList id' to add the contacts too
+      # @return [Activity]
+      def add_remove_contacts_from_lists_activity_from_file(file_name, contents, lists)
+        url = Util::Config.get('endpoints.base_url') +
+              Util::Config.get('endpoints.remove_from_lists_activity')
+        url = build_url(url)
+
+        payload = { :file_name => file_name, :lists => lists, :data => contents, :multipart => true }
+
+        response = RestClient.post(url, payload, get_headers())
+        Components::Activity.create(JSON.parse(response.body))
+      end
+
     end
   end
 end

--- a/lib/constantcontact/services/base_service.rb
+++ b/lib/constantcontact/services/base_service.rb
@@ -7,63 +7,65 @@
 module ConstantContact
   module Services
     class BaseService
-      class << self
-        attr_accessor :api_key, :access_token
-
-        protected
-
-        # Return required headers for making an http request with Constant Contact
-        # @param [String] content_type - The MIME type of the body of the request, default is 'application/json'
-        # @return [Hash] - authorization headers
-        def get_headers(content_type = 'application/json')
-          {
-            :content_type   => content_type,
-            :accept         => 'application/json',
-            :authorization  => "Bearer #{BaseService.access_token}",
-            :user_agent     => "AppConnect Ruby SDK v#{ConstantContact::SDK::VERSION} (#{RUBY_DESCRIPTION})",
-            :x_ctct_request_source => "sdk.ruby.#{ConstantContact::SDK::VERSION}"
-          }
-        end
-
-
-        # returns the id of a ConstantContact component
-        def get_id_for(obj)
-          if obj.kind_of? ConstantContact::Components::Component
-            obj.id
-          elsif obj.kind_of? Hash
-            obj["id"]
-          else
-            obj
-          end
-        end
-
-
-        # Build a url from the base url and query parameters hash. Query parameters
-        # should not be URL encoded because this method will handle that
-        # @param [String] url - The base url
-        # @param [Hash] params - A hash with query parameters
-        # @return [String] - the url with query parameters hash 
-        def build_url(url, params = nil)
-          if params.respond_to? :each
-            params.each do |key, value|
-              # Convert dates to CC date format
-              if value.respond_to? :iso8601
-                params[key] = value.iso8601
-              end
-
-              if key.to_s == 'next' && value.match(/^.*?next=(.*)$/)
-                params[key] = $1
-              end
-            end
-          else
-            params ||= {}
-          end
-
-          params['api_key'] = BaseService.api_key
-          url += '?' + Util::Helpers.http_build_query(params)
-        end
-
+      attr_accessor :api_client
+      
+      def initialize(api_client = nil)
+        @api_client = api_client
       end
+
+      protected
+
+      # Return required headers for making an http request with Constant Contact
+      # @param [String] content_type - The MIME type of the body of the request, default is 'application/json'
+      # @return [Hash] - authorization headers
+      def get_headers(content_type = 'application/json')
+        {
+          :content_type   => content_type,
+          :accept         => 'application/json',
+          :authorization  => "Bearer #{api_client.access_token}",
+          :user_agent     => "AppConnect Ruby SDK v#{ConstantContact::SDK::VERSION} (#{RUBY_DESCRIPTION})",
+          :x_ctct_request_source => "sdk.ruby.#{ConstantContact::SDK::VERSION}"
+        }
+      end
+
+
+      # returns the id of a ConstantContact component
+      def get_id_for(obj)
+        if obj.kind_of? ConstantContact::Components::Component
+          obj.id
+        elsif obj.kind_of? Hash
+          obj["id"]
+        else
+          obj
+        end
+      end
+
+
+      # Build a url from the base url and query parameters hash. Query parameters
+      # should not be URL encoded because this method will handle that
+      # @param [String] url - The base url
+      # @param [Hash] params - A hash with query parameters
+      # @return [String] - the url with query parameters hash 
+      def build_url(url, params = nil)
+        if params.respond_to? :each
+          params.each do |key, value|
+            # Convert dates to CC date format
+            if value.respond_to? :iso8601
+              params[key] = value.iso8601
+            end
+
+            if key.to_s == 'next' && value.match(/^.*?next=(.*)$/)
+              params[key] = $1
+            end
+          end
+        else
+          params ||= {}
+        end
+
+        params['api_key'] = api_client.api_key
+        url += '?' + Util::Helpers.http_build_query(params)
+      end
+
     end
   end
 end

--- a/lib/constantcontact/services/campaign_schedule_service.rb
+++ b/lib/constantcontact/services/campaign_schedule_service.rb
@@ -7,95 +7,93 @@
 module ConstantContact
   module Services
     class CampaignScheduleService < BaseService
-      class << self
 
-        # Create a new schedule for a campaign
-        # @param [Integer] campaign_id - Campaign id to be scheduled
-        # @param [Schedule] schedule - Schedule to be created
-        # @return [Schedule]
-        def add_schedule(campaign_id, schedule)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.campaign_schedules'), campaign_id)
-          url = build_url(url)
-          payload = schedule.to_json
-          response = RestClient.post(url, payload, get_headers())
-          Components::Schedule.create(JSON.parse(response.body))
-        end
-
-
-        # Get a list of schedules for a campaign
-        # @param [Integer] campaign_id - Campaign id to be scheduled
-        # @return [Array<Schedule>]
-        def get_schedules(campaign_id)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.campaign_schedules'), campaign_id)
-          url = build_url(url)
-          response = RestClient.get(url, get_headers())
-          body = JSON.parse(response.body)
-
-          schedules = []
-          body.each do |schedule|
-            schedules << Components::Schedule.create(schedule)
-          end
-
-          schedules
-        end
-
-
-        # Get a specific schedule for a campaign
-        # @param [Integer] campaign_id - Campaign id to get a schedule for
-        # @param [Integer] schedule_id - Schedule id to retrieve
-        # @return [Schedule]
-        def get_schedule(campaign_id, schedule_id)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.campaign_schedule'), campaign_id, schedule_id)
-          url = build_url(url)
-          response = RestClient.get(url, get_headers())
-          Components::Schedule.create(JSON.parse(response.body))
-        end
-
-
-        # Delete a specific schedule for a campaign
-        # @param [Integer] campaign_id - Campaign id to delete a schedule for
-        # @param [Integer] schedule_id - Schedule id to delete
-        # @return [Boolean]
-        def delete_schedule(campaign_id, schedule_id)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.campaign_schedule'), campaign_id, schedule_id)
-          url = build_url(url)
-          response = RestClient.delete(url, get_headers())
-          response.code == 204
-        end
-
-
-        # Update a specific schedule for a campaign
-        # @param [Integer] campaign_id - Campaign id to be scheduled
-        # @param [Schedule] schedule - Schedule to retrieve
-        # @return [Schedule]
-        def update_schedule(campaign_id, schedule)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.campaign_schedule'), campaign_id, schedule.id)
-          url = build_url(url)
-          payload = schedule.to_json
-          response = RestClient.put(url, payload, get_headers())
-          Components::Schedule.create(JSON.parse(response.body))
-        end
-
-
-        # Send a test send of a campaign
-        # @param [Integer] campaign_id - Id of campaign to send test of
-        # @param [TestSend] test_send - Test send details
-        # @return [TestSend]
-        def send_test(campaign_id, test_send)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.campaign_test_sends'), campaign_id)
-          url = build_url(url)
-          payload = test_send.to_json
-          response = RestClient.post(url, payload, get_headers())
-          Components::TestSend.create(JSON.parse(response.body))
-        end
-
+      # Create a new schedule for a campaign
+      # @param [Integer] campaign_id - Campaign id to be scheduled
+      # @param [Schedule] schedule - Schedule to be created
+      # @return [Schedule]
+      def add_schedule(campaign_id, schedule)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.campaign_schedules'), campaign_id)
+        url = build_url(url)
+        payload = schedule.to_json
+        response = RestClient.post(url, payload, get_headers())
+        Components::Schedule.create(JSON.parse(response.body))
       end
+
+
+      # Get a list of schedules for a campaign
+      # @param [Integer] campaign_id - Campaign id to be scheduled
+      # @return [Array<Schedule>]
+      def get_schedules(campaign_id)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.campaign_schedules'), campaign_id)
+        url = build_url(url)
+        response = RestClient.get(url, get_headers())
+        body = JSON.parse(response.body)
+
+        schedules = []
+        body.each do |schedule|
+          schedules << Components::Schedule.create(schedule)
+        end
+
+        schedules
+      end
+
+
+      # Get a specific schedule for a campaign
+      # @param [Integer] campaign_id - Campaign id to get a schedule for
+      # @param [Integer] schedule_id - Schedule id to retrieve
+      # @return [Schedule]
+      def get_schedule(campaign_id, schedule_id)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.campaign_schedule'), campaign_id, schedule_id)
+        url = build_url(url)
+        response = RestClient.get(url, get_headers())
+        Components::Schedule.create(JSON.parse(response.body))
+      end
+
+
+      # Delete a specific schedule for a campaign
+      # @param [Integer] campaign_id - Campaign id to delete a schedule for
+      # @param [Integer] schedule_id - Schedule id to delete
+      # @return [Boolean]
+      def delete_schedule(campaign_id, schedule_id)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.campaign_schedule'), campaign_id, schedule_id)
+        url = build_url(url)
+        response = RestClient.delete(url, get_headers())
+        response.code == 204
+      end
+
+
+      # Update a specific schedule for a campaign
+      # @param [Integer] campaign_id - Campaign id to be scheduled
+      # @param [Schedule] schedule - Schedule to retrieve
+      # @return [Schedule]
+      def update_schedule(campaign_id, schedule)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.campaign_schedule'), campaign_id, schedule.id)
+        url = build_url(url)
+        payload = schedule.to_json
+        response = RestClient.put(url, payload, get_headers())
+        Components::Schedule.create(JSON.parse(response.body))
+      end
+
+
+      # Send a test send of a campaign
+      # @param [Integer] campaign_id - Id of campaign to send test of
+      # @param [TestSend] test_send - Test send details
+      # @return [TestSend]
+      def send_test(campaign_id, test_send)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.campaign_test_sends'), campaign_id)
+        url = build_url(url)
+        payload = test_send.to_json
+        response = RestClient.post(url, payload, get_headers())
+        Components::TestSend.create(JSON.parse(response.body))
+      end
+
     end
   end
 end

--- a/lib/constantcontact/services/campaign_tracking_service.rb
+++ b/lib/constantcontact/services/campaign_tracking_service.rb
@@ -7,146 +7,144 @@
 module ConstantContact
   module Services
     class CampaignTrackingService < BaseService
-      class << self
 
-        # Get bounces for a given campaign
-        # @param [String] campaign_id - Campaign id
-        # @param [Hash] params - query parameters to be appended to request
-        # @return [ResultSet<BounceActivity>] - Containing a results array of BounceActivity
-        def get_bounces(campaign_id, params = {})
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.campaign_tracking_bounces'), campaign_id)
-          url = build_url(url, params)
+      # Get bounces for a given campaign
+      # @param [String] campaign_id - Campaign id
+      # @param [Hash] params - query parameters to be appended to request
+      # @return [ResultSet<BounceActivity>] - Containing a results array of BounceActivity
+      def get_bounces(campaign_id, params = {})
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.campaign_tracking_bounces'), campaign_id)
+        url = build_url(url, params)
 
-          response = RestClient.get(url, get_headers())
-          body = JSON.parse(response.body)
+        response = RestClient.get(url, get_headers())
+        body = JSON.parse(response.body)
 
-          bounces = []
-          body['results'].each do |bounce_activity|
-            bounces << Components::BounceActivity.create(bounce_activity)
-          end
-
-          Components::ResultSet.new(bounces, body['meta'])
+        bounces = []
+        body['results'].each do |bounce_activity|
+          bounces << Components::BounceActivity.create(bounce_activity)
         end
 
-
-        # Get clicks for a given campaign
-        # @param [String] campaign_id - Campaign id
-        # @param [Hash] params - query parameters to be appended to request
-        # @return [ResultSet<ClickActivity>] - Containing a results array of ClickActivity
-        def get_clicks(campaign_id, params = {})
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.campaign_tracking_clicks'), campaign_id)
-          url = build_url(url, params)
-
-          response = RestClient.get(url, get_headers())
-          body = JSON.parse(response.body)
-
-          clicks = []
-          body['results'].each do |click_activity|
-            clicks << Components::ClickActivity.create(click_activity)
-          end
-
-          Components::ResultSet.new(clicks, body['meta'])
-        end
-
-
-        # Get forwards for a given campaign
-        # @param [String] campaign_id - Campaign id
-        # @param [Hash] params - query parameters to be appended to request
-        # @return [ResultSet<ForwardActivity>] - Containing a results array of ForwardActivity
-        def get_forwards(campaign_id, params = {})
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.campaign_tracking_forwards'), campaign_id)
-          url = build_url(url, params)
-
-          response = RestClient.get(url, get_headers())
-          body = JSON.parse(response.body)
-
-          forwards = []
-          body['results'].each do |forward_activity|
-            forwards << Components::ForwardActivity.create(forward_activity)
-          end
-
-          Components::ResultSet.new(forwards, body['meta'])
-        end
-
-
-        # Get opens for a given campaign
-        # @param [String] campaign_id - Campaign id
-        # @param [Hash] params - query parameters to be appended to request
-        # @return [ResultSet<OpenActivity>] - Containing a results array of OpenActivity
-        def get_opens(campaign_id, params = {})
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.campaign_tracking_opens'), campaign_id)
-          url = build_url(url, params)
-
-          response = RestClient.get(url, get_headers())
-          body = JSON.parse(response.body)
-
-          opens = []
-          body['results'].each do |open_activity|
-            opens << Components::OpenActivity.create(open_activity)
-          end
-
-          Components::ResultSet.new(opens, body['meta'])
-        end
-
-
-        # Get sends for a given campaign
-        # @param [String] campaign_id - Campaign id
-        # @param [Hash] params - query parameters to be appended to request
-        # @return [ResultSet<SendActivity>] - Containing a results array of SendActivity
-        def get_sends(campaign_id, params = {})
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.campaign_tracking_sends'), campaign_id)
-          url = build_url(url, params)
-
-          response = RestClient.get(url, get_headers())
-          body = JSON.parse(response.body)
-
-          sends = []
-          body['results'].each do |send_activity|
-            sends << Components::SendActivity.create(send_activity)
-          end
-
-          Components::ResultSet.new(sends, body['meta'])
-        end
-
-
-        # Get unsubscribes for a given campaign
-        # @param [String] campaign_id - Campaign id
-        # @param [Hash] params - query params to be appended to request
-        # @return [ResultSet<UnsubscribeActivity>] - Containing a results array of UnsubscribeActivity
-        def get_unsubscribes(campaign_id, params = {})
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.campaign_tracking_unsubscribes'), campaign_id)
-          url = build_url(url, params)
-
-          response = RestClient.get(url, get_headers())
-          body = JSON.parse(response.body)
-
-          unsubscribes = []
-          body['results'].each do |unsubscribe_activity|
-            unsubscribes << Components::UnsubscribeActivity.create(unsubscribe_activity)
-          end
-
-          Components::ResultSet.new(unsubscribes, body['meta'])
-        end
-
-
-        # Get a summary of reporting data for a given campaign
-        # @param [Integer] campaign_id - Campaign id
-        # @return [TrackingSummary]
-        def get_summary(campaign_id)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.campaign_tracking_summary'), campaign_id)
-          url = build_url(url)
-          response = RestClient.get(url, get_headers())
-          Components::TrackingSummary.create(JSON.parse(response.body))
-        end
-
+        Components::ResultSet.new(bounces, body['meta'])
       end
+
+
+      # Get clicks for a given campaign
+      # @param [String] campaign_id - Campaign id
+      # @param [Hash] params - query parameters to be appended to request
+      # @return [ResultSet<ClickActivity>] - Containing a results array of ClickActivity
+      def get_clicks(campaign_id, params = {})
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.campaign_tracking_clicks'), campaign_id)
+        url = build_url(url, params)
+
+        response = RestClient.get(url, get_headers())
+        body = JSON.parse(response.body)
+
+        clicks = []
+        body['results'].each do |click_activity|
+          clicks << Components::ClickActivity.create(click_activity)
+        end
+
+        Components::ResultSet.new(clicks, body['meta'])
+      end
+
+
+      # Get forwards for a given campaign
+      # @param [String] campaign_id - Campaign id
+      # @param [Hash] params - query parameters to be appended to request
+      # @return [ResultSet<ForwardActivity>] - Containing a results array of ForwardActivity
+      def get_forwards(campaign_id, params = {})
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.campaign_tracking_forwards'), campaign_id)
+        url = build_url(url, params)
+
+        response = RestClient.get(url, get_headers())
+        body = JSON.parse(response.body)
+
+        forwards = []
+        body['results'].each do |forward_activity|
+          forwards << Components::ForwardActivity.create(forward_activity)
+        end
+
+        Components::ResultSet.new(forwards, body['meta'])
+      end
+
+
+      # Get opens for a given campaign
+      # @param [String] campaign_id - Campaign id
+      # @param [Hash] params - query parameters to be appended to request
+      # @return [ResultSet<OpenActivity>] - Containing a results array of OpenActivity
+      def get_opens(campaign_id, params = {})
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.campaign_tracking_opens'), campaign_id)
+        url = build_url(url, params)
+
+        response = RestClient.get(url, get_headers())
+        body = JSON.parse(response.body)
+
+        opens = []
+        body['results'].each do |open_activity|
+          opens << Components::OpenActivity.create(open_activity)
+        end
+
+        Components::ResultSet.new(opens, body['meta'])
+      end
+
+
+      # Get sends for a given campaign
+      # @param [String] campaign_id - Campaign id
+      # @param [Hash] params - query parameters to be appended to request
+      # @return [ResultSet<SendActivity>] - Containing a results array of SendActivity
+      def get_sends(campaign_id, params = {})
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.campaign_tracking_sends'), campaign_id)
+        url = build_url(url, params)
+
+        response = RestClient.get(url, get_headers())
+        body = JSON.parse(response.body)
+
+        sends = []
+        body['results'].each do |send_activity|
+          sends << Components::SendActivity.create(send_activity)
+        end
+
+        Components::ResultSet.new(sends, body['meta'])
+      end
+
+
+      # Get unsubscribes for a given campaign
+      # @param [String] campaign_id - Campaign id
+      # @param [Hash] params - query params to be appended to request
+      # @return [ResultSet<UnsubscribeActivity>] - Containing a results array of UnsubscribeActivity
+      def get_unsubscribes(campaign_id, params = {})
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.campaign_tracking_unsubscribes'), campaign_id)
+        url = build_url(url, params)
+
+        response = RestClient.get(url, get_headers())
+        body = JSON.parse(response.body)
+
+        unsubscribes = []
+        body['results'].each do |unsubscribe_activity|
+          unsubscribes << Components::UnsubscribeActivity.create(unsubscribe_activity)
+        end
+
+        Components::ResultSet.new(unsubscribes, body['meta'])
+      end
+
+
+      # Get a summary of reporting data for a given campaign
+      # @param [Integer] campaign_id - Campaign id
+      # @return [TrackingSummary]
+      def get_summary(campaign_id)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.campaign_tracking_summary'), campaign_id)
+        url = build_url(url)
+        response = RestClient.get(url, get_headers())
+        Components::TrackingSummary.create(JSON.parse(response.body))
+      end
+
     end
   end
 end

--- a/lib/constantcontact/services/contact_service.rb
+++ b/lib/constantcontact/services/contact_service.rb
@@ -7,99 +7,97 @@
 module ConstantContact
   module Services
     class ContactService < BaseService
-      class << self
 
-        # Get an array of contacts
-        # @param [Hash] params - query parameters to be appended to the request
-        # @return [ResultSet<Contact>]
-        def get_contacts(params = {})
-          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.contacts')
-          url = build_url(url, params)
+      # Get an array of contacts
+      # @param [Hash] params - query parameters to be appended to the request
+      # @return [ResultSet<Contact>]
+      def get_contacts(params = {})
+        url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.contacts')
+        url = build_url(url, params)
 
-          response = RestClient.get(url, get_headers())
-          body = JSON.parse(response.body)
+        response = RestClient.get(url, get_headers())
+        body = JSON.parse(response.body)
 
-          contacts = []
-          body['results'].each do |contact|
-            contacts << Components::Contact.create(contact)
-          end
-
-          Components::ResultSet.new(contacts, body['meta'])
+        contacts = []
+        body['results'].each do |contact|
+          contacts << Components::Contact.create(contact)
         end
 
-
-        # Get contact details for a specific contact
-        # @param [Integer] contact_id - Unique contact id
-        # @return [Contact]
-        def get_contact(contact_id)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.contact'), contact_id)
-          url = build_url(url)
-          response = RestClient.get(url, get_headers())
-          Components::Contact.create(JSON.parse(response.body))
-        end
-
-
-        # Add a new contact to the Constant Contact account
-        # @param [Contact] contact - Contact to add
-        # @param [Boolean] params - query params to be appended to the request
-        # @return [Contact]
-        def add_contact(contact, params = {})
-          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.contacts')
-          url = build_url(url, params)
-          payload = contact.to_json
-          response = RestClient.post(url, payload, get_headers())
-          Components::Contact.create(JSON.parse(response.body))
-        end
-
-
-        # Delete contact details for a specific contact
-        # @param [Integer] contact_id - Unique contact id
-        # @return [Boolean]
-        def delete_contact(contact_id)
-          url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.contact'), contact_id)
-          url = build_url(url)
-          response = RestClient.delete(url, get_headers())
-          response.code == 204
-        end
-
-
-        # Delete a contact from all contact lists
-        # @param [Integer] contact_id - Contact id to be removed from lists
-        # @return [Boolean]
-        def delete_contact_from_lists(contact_id)
-          url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.contact_lists'), contact_id)
-          url = build_url(url)
-          response = RestClient.delete(url, get_headers())
-          response.code == 204
-        end
-
-
-        # Delete a contact from a specific contact list
-        # @param [Integer] contact_id - Contact id to be removed
-        # @param [Integer] list_id - ContactList id to remove the contact from
-        # @return [Boolean]
-        def delete_contact_from_list(contact_id, list_id)
-          url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.contact_list'), contact_id, list_id)
-          url = build_url(url)
-          response = RestClient.delete(url, get_headers())
-          response.code == 204
-        end
-
-
-        # Update contact details for a specific contact
-        # @param [Contact] contact - Contact to be updated
-        # @param [Hash] params - query params to be appended to the request
-        # @return [Contact]
-        def update_contact(contact, params = {})
-          url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.contact'), contact.id)
-          url = build_url(url, params)
-          payload = contact.to_json
-          response = RestClient.put(url, payload, get_headers())
-          Components::Contact.create(JSON.parse(response.body))
-        end
-
+        Components::ResultSet.new(contacts, body['meta'])
       end
+
+
+      # Get contact details for a specific contact
+      # @param [Integer] contact_id - Unique contact id
+      # @return [Contact]
+      def get_contact(contact_id)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.contact'), contact_id)
+        url = build_url(url)
+        response = RestClient.get(url, get_headers())
+        Components::Contact.create(JSON.parse(response.body))
+      end
+
+
+      # Add a new contact to the Constant Contact account
+      # @param [Contact] contact - Contact to add
+      # @param [Boolean] params - query params to be appended to the request
+      # @return [Contact]
+      def add_contact(contact, params = {})
+        url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.contacts')
+        url = build_url(url, params)
+        payload = contact.to_json
+        response = RestClient.post(url, payload, get_headers())
+        Components::Contact.create(JSON.parse(response.body))
+      end
+
+
+      # Delete contact details for a specific contact
+      # @param [Integer] contact_id - Unique contact id
+      # @return [Boolean]
+      def delete_contact(contact_id)
+        url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.contact'), contact_id)
+        url = build_url(url)
+        response = RestClient.delete(url, get_headers())
+        response.code == 204
+      end
+
+
+      # Delete a contact from all contact lists
+      # @param [Integer] contact_id - Contact id to be removed from lists
+      # @return [Boolean]
+      def delete_contact_from_lists(contact_id)
+        url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.contact_lists'), contact_id)
+        url = build_url(url)
+        response = RestClient.delete(url, get_headers())
+        response.code == 204
+      end
+
+
+      # Delete a contact from a specific contact list
+      # @param [Integer] contact_id - Contact id to be removed
+      # @param [Integer] list_id - ContactList id to remove the contact from
+      # @return [Boolean]
+      def delete_contact_from_list(contact_id, list_id)
+        url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.contact_list'), contact_id, list_id)
+        url = build_url(url)
+        response = RestClient.delete(url, get_headers())
+        response.code == 204
+      end
+
+
+      # Update contact details for a specific contact
+      # @param [Contact] contact - Contact to be updated
+      # @param [Hash] params - query params to be appended to the request
+      # @return [Contact]
+      def update_contact(contact, params = {})
+        url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.contact'), contact.id)
+        url = build_url(url, params)
+        payload = contact.to_json
+        response = RestClient.put(url, payload, get_headers())
+        Components::Contact.create(JSON.parse(response.body))
+      end
+
     end
   end
 end

--- a/lib/constantcontact/services/contact_tracking_service.rb
+++ b/lib/constantcontact/services/contact_tracking_service.rb
@@ -7,146 +7,144 @@
 module ConstantContact
   module Services
     class ContactTrackingService < BaseService
-      class << self
 
-        # Get bounces for a given contact
-        # @param [String] contact_id - Contact id
-        # @param [Hash] params - query parameters to be appended to request
-        # @return [ResultSet<BounceActivity>] - Containing a results array of BounceActivity
-        def get_bounces(contact_id, params = {})
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.contact_tracking_bounces'), contact_id)
-          url = build_url(url, params)
+      # Get bounces for a given contact
+      # @param [String] contact_id - Contact id
+      # @param [Hash] params - query parameters to be appended to request
+      # @return [ResultSet<BounceActivity>] - Containing a results array of BounceActivity
+      def get_bounces(contact_id, params = {})
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.contact_tracking_bounces'), contact_id)
+        url = build_url(url, params)
 
-          response = RestClient.get(url, get_headers())
-          body = JSON.parse(response.body)
+        response = RestClient.get(url, get_headers())
+        body = JSON.parse(response.body)
 
-          bounces = []
-          body['results'].each do |bounce_activity|
-            bounces << Components::BounceActivity.create(bounce_activity)
-          end
-
-          Components::ResultSet.new(bounces, body['meta'])
+        bounces = []
+        body['results'].each do |bounce_activity|
+          bounces << Components::BounceActivity.create(bounce_activity)
         end
 
-
-        # Get clicks for a given contact
-        # @param [String] contact_id - Contact id
-        # @param [Hash] params - query parameters to be appended to request
-        # @return [ResultSet<ClickActivity>] - Containing a results array of ClickActivity
-        def get_clicks(contact_id, params = {})
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.contact_tracking_clicks'), contact_id)
-          url = build_url(url, params)
-
-          response = RestClient.get(url, get_headers())
-          body = JSON.parse(response.body)
-
-          clicks = []
-          body['results'].each do |click_activity|
-            clicks << Components::ClickActivity.create(click_activity)
-          end
-
-          Components::ResultSet.new(clicks, body['meta'])
-        end
-
-
-        # Get forwards for a given contact
-        # @param [String] contact_id - Contact id
-        # @param [Hash] params - query parameters to be appended to request
-        # @return [ResultSet<ForwardActivity>] - Containing a results array of ForwardActivity
-        def get_forwards(contact_id, params = {})
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.contact_tracking_forwards'), contact_id)
-          url = build_url(url, params)
-
-          response = RestClient.get(url, get_headers())
-          body = JSON.parse(response.body)
-
-          forwards = []
-          body['results'].each do |forward_activity|
-            forwards << Components::ForwardActivity.create(forward_activity)
-          end
-
-          Components::ResultSet.new(forwards, body['meta'])
-        end
-
-
-        # Get opens for a given contact
-        # @param [String] contact_id - Contact id
-        # @param [Hash] params - query parameters to be appended to request
-        # @return [ResultSet<OpenActivity>] - Containing a results array of OpenActivity
-        def get_opens(contact_id, params = {})
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.contact_tracking_opens'), contact_id)
-          url = build_url(url, params)
-
-          response = RestClient.get(url, get_headers())
-          body = JSON.parse(response.body)
-
-          opens = []
-          body['results'].each do |open_activity|
-            opens << Components::OpenActivity.create(open_activity)
-          end
-
-          Components::ResultSet.new(opens, body['meta'])
-        end
-
-
-        # Get sends for a given contact
-        # @param [String] contact_id - Contact id
-        # @param [Hash] params - query parameters to be appended to request
-        # @return [ResultSet<SendActivity>] - Containing a results array of SendActivity
-        def get_sends(contact_id, params = {})
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.contact_tracking_sends'), contact_id)
-          url = build_url(url, params)
-
-          response = RestClient.get(url, get_headers())
-          body = JSON.parse(response.body)
-
-          sends = []
-          body['results'].each do |send_activity|
-            sends << Components::SendActivity.create(send_activity)
-          end
-
-          Components::ResultSet.new(sends, body['meta'])
-        end
-
-
-        # Get unsubscribes for a given contact
-        # @param [String] contact_id - Contact id
-        # @param [Hash] params - query parameters to be appended to request
-        # @return [ResultSet<UnsubscribeActivity>] - Containing a results array of UnsubscribeActivity
-        def get_unsubscribes(contact_id, params = {})
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.contact_tracking_unsubscribes'), contact_id)
-          url = build_url(url, params)
-
-          response = RestClient.get(url, get_headers())
-          body = JSON.parse(response.body)
-
-          unsubscribes = []
-          body['results'].each do |unsubscribe_activity|
-            unsubscribes << Components::UnsubscribeActivity.create(unsubscribe_activity)
-          end
-
-          Components::ResultSet.new(unsubscribes, body['meta'])
-        end
-
-
-        # Get a summary of reporting data for a given contact
-        # @param [String] contact_id - Contact id
-        # @return [TrackingSummary]
-        def get_summary(contact_id)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.contact_tracking_summary'), contact_id)
-          url = build_url(url)
-          response = RestClient.get(url, get_headers())
-          Components::TrackingSummary.create(JSON.parse(response.body))
-        end
-
+        Components::ResultSet.new(bounces, body['meta'])
       end
+
+
+      # Get clicks for a given contact
+      # @param [String] contact_id - Contact id
+      # @param [Hash] params - query parameters to be appended to request
+      # @return [ResultSet<ClickActivity>] - Containing a results array of ClickActivity
+      def get_clicks(contact_id, params = {})
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.contact_tracking_clicks'), contact_id)
+        url = build_url(url, params)
+
+        response = RestClient.get(url, get_headers())
+        body = JSON.parse(response.body)
+
+        clicks = []
+        body['results'].each do |click_activity|
+          clicks << Components::ClickActivity.create(click_activity)
+        end
+
+        Components::ResultSet.new(clicks, body['meta'])
+      end
+
+
+      # Get forwards for a given contact
+      # @param [String] contact_id - Contact id
+      # @param [Hash] params - query parameters to be appended to request
+      # @return [ResultSet<ForwardActivity>] - Containing a results array of ForwardActivity
+      def get_forwards(contact_id, params = {})
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.contact_tracking_forwards'), contact_id)
+        url = build_url(url, params)
+
+        response = RestClient.get(url, get_headers())
+        body = JSON.parse(response.body)
+
+        forwards = []
+        body['results'].each do |forward_activity|
+          forwards << Components::ForwardActivity.create(forward_activity)
+        end
+
+        Components::ResultSet.new(forwards, body['meta'])
+      end
+
+
+      # Get opens for a given contact
+      # @param [String] contact_id - Contact id
+      # @param [Hash] params - query parameters to be appended to request
+      # @return [ResultSet<OpenActivity>] - Containing a results array of OpenActivity
+      def get_opens(contact_id, params = {})
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.contact_tracking_opens'), contact_id)
+        url = build_url(url, params)
+
+        response = RestClient.get(url, get_headers())
+        body = JSON.parse(response.body)
+
+        opens = []
+        body['results'].each do |open_activity|
+          opens << Components::OpenActivity.create(open_activity)
+        end
+
+        Components::ResultSet.new(opens, body['meta'])
+      end
+
+
+      # Get sends for a given contact
+      # @param [String] contact_id - Contact id
+      # @param [Hash] params - query parameters to be appended to request
+      # @return [ResultSet<SendActivity>] - Containing a results array of SendActivity
+      def get_sends(contact_id, params = {})
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.contact_tracking_sends'), contact_id)
+        url = build_url(url, params)
+
+        response = RestClient.get(url, get_headers())
+        body = JSON.parse(response.body)
+
+        sends = []
+        body['results'].each do |send_activity|
+          sends << Components::SendActivity.create(send_activity)
+        end
+
+        Components::ResultSet.new(sends, body['meta'])
+      end
+
+
+      # Get unsubscribes for a given contact
+      # @param [String] contact_id - Contact id
+      # @param [Hash] params - query parameters to be appended to request
+      # @return [ResultSet<UnsubscribeActivity>] - Containing a results array of UnsubscribeActivity
+      def get_unsubscribes(contact_id, params = {})
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.contact_tracking_unsubscribes'), contact_id)
+        url = build_url(url, params)
+
+        response = RestClient.get(url, get_headers())
+        body = JSON.parse(response.body)
+
+        unsubscribes = []
+        body['results'].each do |unsubscribe_activity|
+          unsubscribes << Components::UnsubscribeActivity.create(unsubscribe_activity)
+        end
+
+        Components::ResultSet.new(unsubscribes, body['meta'])
+      end
+
+
+      # Get a summary of reporting data for a given contact
+      # @param [String] contact_id - Contact id
+      # @return [TrackingSummary]
+      def get_summary(contact_id)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.contact_tracking_summary'), contact_id)
+        url = build_url(url)
+        response = RestClient.get(url, get_headers())
+        Components::TrackingSummary.create(JSON.parse(response.body))
+      end
+
     end
   end
 end

--- a/lib/constantcontact/services/email_marketing_service.rb
+++ b/lib/constantcontact/services/email_marketing_service.rb
@@ -7,88 +7,86 @@
 module ConstantContact
   module Services
     class EmailMarketingService < BaseService
-      class << self
 
-        # Create a new campaign
-        # @param [Campaign] campaign - Campaign to be created
-        # @return [Campaign]
-        def add_campaign(campaign)
-          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.campaigns')
-          url = build_url(url)
-          payload = campaign.to_json
-          response = RestClient.post(url, payload, get_headers())
-          Components::Campaign.create(JSON.parse(response.body))
-        end
-
-
-        # Get a set of campaigns
-        # @param [Hash] params - query parameters to be appended to the request
-        # @return [ResultSet<Campaign>]
-        def get_campaigns(params = {})
-          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.campaigns')
-          url = build_url(url, params)
-
-          response = RestClient.get(url, get_headers())
-          body = JSON.parse(response.body)
-
-          campaigns = []
-          body['results'].each do |campaign|
-            campaigns << Components::Campaign.create_summary(campaign)
-          end
-
-          Components::ResultSet.new(campaigns, body['meta'])
-        end
-
-
-        # Get campaign details for a specific campaign
-        # @param [Integer] campaign_id - Valid campaign id
-        # @return [Campaign]
-        def get_campaign(campaign_id)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.campaign'), campaign_id)
-          url = build_url(url)
-          response = RestClient.get(url, get_headers())
-          Components::Campaign.create(JSON.parse(response.body))
-        end
-
-
-        # Get the preview of the given campaign
-        # @param [Integer] campaign_id - Valid campaign id
-        # @return [CampaignPreview]
-        def get_campaign_preview(campaign_id)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.campaign_preview'), campaign_id)
-          url = build_url(url)
-          response = RestClient.get(url, get_headers())
-          Components::CampaignPreview.create(JSON.parse(response.body))
-        end
-
-
-        # Delete an email campaign
-        # @param [Integer] campaign_id - Valid campaign id
-        # @return [Boolean]
-        def delete_campaign(campaign_id)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.campaign'), campaign_id)
-          url = build_url(url)
-          response = RestClient.delete(url, get_headers())
-          response.code == 204
-        end
-
-
-        # Update a specific email campaign
-        # @param [Campaign] campaign - Campaign to be updated
-        # @return [Campaign]
-        def update_campaign(campaign)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.campaign'), campaign.id)
-          url = build_url(url)
-          payload = campaign.to_json
-          response = RestClient.put(url, payload, get_headers())
-          Components::Campaign.create(JSON.parse(response.body))
-        end
-
+      # Create a new campaign
+      # @param [Campaign] campaign - Campaign to be created
+      # @return [Campaign]
+      def add_campaign(campaign)
+        url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.campaigns')
+        url = build_url(url)
+        payload = campaign.to_json
+        response = RestClient.post(url, payload, get_headers())
+        Components::Campaign.create(JSON.parse(response.body))
       end
+
+
+      # Get a set of campaigns
+      # @param [Hash] params - query parameters to be appended to the request
+      # @return [ResultSet<Campaign>]
+      def get_campaigns(params = {})
+        url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.campaigns')
+        url = build_url(url, params)
+
+        response = RestClient.get(url, get_headers())
+        body = JSON.parse(response.body)
+
+        campaigns = []
+        body['results'].each do |campaign|
+          campaigns << Components::Campaign.create_summary(campaign)
+        end
+
+        Components::ResultSet.new(campaigns, body['meta'])
+      end
+
+
+      # Get campaign details for a specific campaign
+      # @param [Integer] campaign_id - Valid campaign id
+      # @return [Campaign]
+      def get_campaign(campaign_id)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.campaign'), campaign_id)
+        url = build_url(url)
+        response = RestClient.get(url, get_headers())
+        Components::Campaign.create(JSON.parse(response.body))
+      end
+
+
+      # Get the preview of the given campaign
+      # @param [Integer] campaign_id - Valid campaign id
+      # @return [CampaignPreview]
+      def get_campaign_preview(campaign_id)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.campaign_preview'), campaign_id)
+        url = build_url(url)
+        response = RestClient.get(url, get_headers())
+        Components::CampaignPreview.create(JSON.parse(response.body))
+      end
+
+
+      # Delete an email campaign
+      # @param [Integer] campaign_id - Valid campaign id
+      # @return [Boolean]
+      def delete_campaign(campaign_id)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.campaign'), campaign_id)
+        url = build_url(url)
+        response = RestClient.delete(url, get_headers())
+        response.code == 204
+      end
+
+
+      # Update a specific email campaign
+      # @param [Campaign] campaign - Campaign to be updated
+      # @return [Campaign]
+      def update_campaign(campaign)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.campaign'), campaign.id)
+        url = build_url(url)
+        payload = campaign.to_json
+        response = RestClient.put(url, payload, get_headers())
+        Components::Campaign.create(JSON.parse(response.body))
+      end
+
     end
   end
 end

--- a/lib/constantcontact/services/event_spot_service.rb
+++ b/lib/constantcontact/services/event_spot_service.rb
@@ -7,442 +7,440 @@
 module ConstantContact
   module Services
     class EventSpotService < BaseService
-      class << self
 
-        # Create a new event
-        # @param [Event] event - Event to be created
-        # @return [Event]
-        def add_event(event)
-          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.events')
-          url = build_url(url)
-          payload = event.to_json
-          response = RestClient.post(url, payload, get_headers())
-          Components::Event.create(JSON.parse(response.body))
-        end
-
-
-        # Get a set of events
-        # @param [Hash] opts query parameters to be appended to the request
-        # @option opts [String] status email campaigns status of DRAFT, RUNNING, SENT, SCHEDULED.
-        # @option opts [String] modified_since ISO-8601 date string to return campaigns modified since then.
-        # @option opts [Integer] limit number of campaigns to return, 1 to 50.
-        # @return [ResultSet<Event>]
-        def get_events(opts = {})
-          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.events')
-          url = build_url(url, opts)
-
-          response = RestClient.get(url, get_headers())
-          body = JSON.parse(response.body)
-
-          events = body['results'].collect do |event|
-            Components::Event.create_summary(event)
-          end
-
-          Components::ResultSet.new(events, body['meta'])
-        end
-
-
-        # Get event details for a specific event
-        # @param [Integer] event - Valid event id
-        # @return [Event]
-        def get_event(event)
-          event_id = get_id_for(event)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.event'), event_id)
-          url = build_url(url)
-          response = RestClient.get(url, get_headers())
-          Components::Event.create(JSON.parse(response.body))
-        end
-
-
-        # Update a specific EventSpot event
-        # @param [Event] event - Event to be updated
-        # @return [Event]
-        def update_event(event)
-          event_id = get_id_for(event)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.event'), event_id)
-          url = build_url(url)
-          payload = event.to_json
-          response = RestClient.put(url, payload, get_headers())
-          Components::Event.create(JSON.parse(response.body))
-        end
-
-
-        # Publish a specific EventSpot event
-        # @param [Event] event - Event to be updated
-        # @return [Event]
-        def publish_event(event)
-          event_id = get_id_for(event)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.event'), event_id)
-          url = build_url(url)
-          payload = [{:op => "REPLACE", :path => "#/status", :value => "ACTIVE"}].to_json
-          response = RestClient.patch(url, payload, get_headers())
-          Components::Event.create(JSON.parse(response.body))
-        end
-
-
-        # Cancel a specific EventSpot event
-        # @param [Event] event - Event to be updated
-        # @return [Event]
-        def cancel_event(event)
-          event_id = get_id_for(event)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.event'), event_id)
-          url = build_url(url)
-          payload = [{ :op => "REPLACE", :path => "#/status", :value => "CANCELLED" }].to_json
-          response = RestClient.patch(url, payload, get_headers())
-          Components::Event.create(JSON.parse(response.body))
-        end
-
-
-        # Create a new event fee
-        # @param [Integer] event - Valid event id
-        # @param [EventFee] fee - Event fee to be created
-        # @return [EventFee]
-        def add_fee(event, fee)
-          event_id = get_id_for(event)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.event_fees'), event_id)
-          url = build_url(url)
-          payload = fee.to_json
-          response = RestClient.post(url, payload, get_headers())
-          Components::EventFee.create(JSON.parse(response.body))
-        end
-
-
-        # Get an array of event fees
-        # @param [Integer] event - Valid event id
-        # @return [Array<EventFee>]
-        def get_fees(event)
-          event_id = get_id_for(event)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.event_fees'), event_id)
-          url = build_url(url)
-
-          response = RestClient.get(url, get_headers())
-          body = JSON.parse(response.body)
-          
-          fees = body.collect do |fee|
-            Components::EventFee.create(fee)
-          end
-        end
-
-
-        # Get an individual event fee
-        # @param [Integer] event - Valid event id
-        # @param [Integer] fee - Valid fee id
-        # @return [EventFee]
-        def get_fee(event, fee)
-          event_id  = get_id_for(event)
-          fee_id    = get_id_for(fee)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.event_fee'), event_id, fee_id)
-          url = build_url(url)
-
-          response = RestClient.get(url, get_headers())
-         fee = Components::EventFee.create(JSON.parse(response.body))
-        end
-
-
-        # Update an individual event fee
-        # @param [Integer] event - Valid event id
-        # @param [Integer] fee - Valid fee id
-        # @return [EventFee]
-        def update_fee(event, fee)
-          event_id  = get_id_for(event)
-          if fee.kind_of?(ConstantContact::Components::EventFee)
-            fee_id = fee.id
-          elsif fee.kind_of?(Hash)
-            fee_id = fee['id']
-          else
-            raise ArgumentError.new "Fee must be a Hash or ConstantContact::Components::Fee"
-          end
-
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.event_fee'), event_id, fee_id)
-          url = build_url(url)
-          payload = fee.to_json
-
-          response = RestClient.put(url, payload, get_headers())
-         fee = Components::EventFee.create(JSON.parse(response.body))
-        end
-
-
-        # Delete an individual event fee
-        # @param [Integer] event - Valid event id
-        # @param [Integer] fee - Valid fee id
-        # @return [Boolean]
-        def delete_fee(event, fee)
-          event_id  = get_id_for(event)
-          fee_id    = get_id_for(fee)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.event_fee'), event_id, fee_id)
-          url = build_url(url)
-
-          response = RestClient.delete(url, get_headers())
-          response.code == 204
-        end
-
-
-        # Get a set of event registrants
-        # @param [Integer] event - Valid event id
-        # @return [ResultSet<Registrant>]
-        def get_registrants(event)
-          event_id  = event.kind_of?(ConstantContact::Components::Event) ? event.id : event
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.event_registrants'), event_id)
-          url = build_url(url)
-
-          response = RestClient.get(url, get_headers())
-          body = JSON.parse(response.body)
-
-          registrants = body['results'].collect do |registrant|
-            Components::Registrant.create(registrant)
-          end
-
-          Components::ResultSet.new(registrants, body['meta'])
-        end
-
-
-        # Get an individual event registant
-        # @param [Integer] event - Valid event id
-        # @param [Integer] registrant - Valid fee id
-        # @return [Registrant]
-        def get_registrant(event, registrant)
-          event_id      = get_id_for(event)
-          registrant_id  = get_id_for(registrant)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.event_registrant'), event_id, registrant_id)
-          url = build_url(url)
-
-          response = RestClient.get(url, get_headers())
-          Components::Registrant.create(JSON.parse(response.body))
-        end
-
-
-        # Get an array of event items for an individual event
-        # @param [Integer] event_id - event id to retrieve items for
-        # @return [Array<EventItem>]
-        def get_event_items(event_id)
-          url = Util::Config.get('endpoints.base_url') + 
-                sprintf(Util::Config.get('endpoints.event_items'), event_id)
-          url = build_url(url)
-          response = RestClient.get(url, get_headers())
-
-          event_items = []
-          JSON.parse(response.body).each do |event_item|
-            event_items << Components::EventItem.create(event_item)
-          end
-
-          event_items
-        end
-
-
-        # Get an individual event item
-        # @param [Integer] event_id - id of event to retrieve item for
-        # @param [Integer] item_id - id of item to be retrieved
-        # @return [EventItem]
-        def get_event_item(event_id, item_id)
-          url = Util::Config.get('endpoints.base_url') + 
-                sprintf(Util::Config.get('endpoints.event_item'), event_id, item_id)
-          url = build_url(url)
-          response = RestClient.get(url, get_headers())
-          Components::EventItem.create(JSON.parse(response.body))
-        end
-
-
-        # Create a new event item for an event
-        # @param [Integer] event_id - id of event to be associated with the event item
-        # @param [EventItem] event_item - event item to be created
-        # @return [EventItem]
-        def add_event_item(event_id, event_item)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.event_items'), event_id)
-          url = build_url(url)
-          payload = event_item.to_json
-          response = RestClient.post(url, payload, get_headers())
-          Components::EventItem.create(JSON.parse(response.body))
-        end
-
-
-        # Delete a specific event item for an event
-        # @param [Integer] event_id - id of event to delete an event item for
-        # @param [Integer] item_id - id of event item to be deleted
-        # @return [Boolean]
-        def delete_event_item(event_id, item_id)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.event_item'), event_id, item_id)
-          url = build_url(url)
-          response = RestClient.delete(url, get_headers())
-          response.code == 204
-        end
-
-
-        # Update a specific event item for an event
-        # @param [Integer] event_id - id of event associated with the event item
-        # @param [EventItem] event_item - event item to be updated
-        # @return [EventItem]
-        def update_event_item(event_id, event_item)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.event_item'), event_id, event_item.id)
-          url = build_url(url)
-          payload = event_item.to_json
-          response = RestClient.put(url, payload, get_headers())
-          Components::EventItem.create(JSON.parse(response.body))
-        end
-
-
-        # Get an array of attributes for an individual event item
-        # @param [Integer] event_id - event id to retrieve item for
-        # @param [Integer] item_id - event item id to retrieve attributes for
-        # @return [Array<EventItemAttribute>]
-        def get_event_item_attributes(event_id, item_id)
-          url = Util::Config.get('endpoints.base_url') + 
-                sprintf(Util::Config.get('endpoints.event_item_attributes'), event_id, item_id)
-          url = build_url(url)
-          response = RestClient.get(url, get_headers())
-
-          event_item_attributes = []
-          JSON.parse(response.body).each do |event_item_attribute|
-            event_item_attributes << Components::EventItemAttribute.create(event_item_attribute)
-          end
-
-          event_item_attributes
-        end
-
-
-        # Get an individual event item attribute
-        # @param [Integer] event_id - id of event to retrieve item for
-        # @param [Integer] item_id - id of item to retrieve attribute for
-        # @param [Integer] attribute_id - id of attribute to be retrieved
-        # @return [EventItemAttribute]
-        def get_event_item_attribute(event_id, item_id, attribute_id)
-          url = Util::Config.get('endpoints.base_url') + 
-                sprintf(Util::Config.get('endpoints.event_item_attribute'), event_id, item_id, attribute_id)
-          url = build_url(url)
-          response = RestClient.get(url, get_headers())
-          Components::EventItemAttribute.create(JSON.parse(response.body))
-        end
-
-
-        # Create a new event item attribute for an event item
-        # @param [Integer] event_id - id of event to be associated with the event item attribute
-        # @param [Integer] item_id - id of event item to be associated with the event item attribute
-        # @param [EventItemAttribute] event_item_attribute - event item attribute to be created
-        # @return [EventItemAttribute]
-        def add_event_item_attribute(event_id, item_id, event_item_attribute)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.event_item_attributes'), event_id, item_id)
-          url = build_url(url)
-          payload = event_item_attribute.to_json
-          response = RestClient.post(url, payload, get_headers())
-          Components::EventItemAttribute.create(JSON.parse(response.body))
-        end
-
-
-        # Delete a specific event item for an event
-        # @param [Integer] event_id - id of event to delete an event item attribute for
-        # @param [Integer] item_id - id of event item to delete an event item attribute for
-        # @param [Integer] attribute_id - id of attribute to be deleted
-        # @return [Boolean]
-        def delete_event_item_attribute(event_id, item_id, attribute_id)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.event_item_attribute'), event_id, item_id, attribute_id)
-          url = build_url(url)
-          response = RestClient.delete(url, get_headers())
-          response.code == 204
-        end
-
-
-        # Update a specific event item attribute for an event item
-        # @param [Integer] event_id - id of event associated with the event item
-        # @param [Integer] item_id - id of event item associated with the event item attribute
-        # @param [EventItemAttribute] event_item_attribute - event item to be updated
-        # @return [EventItemAttribute]
-        def update_event_item_attribute(event_id, item_id, event_item_attribute)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.event_item'), event_id, item_id, event_item_attribute.id)
-          url = build_url(url)
-          payload = event_item_attribute.to_json
-          response = RestClient.put(url, payload, get_headers())
-          Components::EventItemAttribute.create(JSON.parse(response.body))
-        end
-
-
-        # Get an array of promocodes for an individual event
-        # @param [Integer] event_id - event id to retrieve promocodes for
-        # @return [Array<Promocode>]
-        def get_promocodes(event_id)
-          url = Util::Config.get('endpoints.base_url') + 
-                sprintf(Util::Config.get('endpoints.event_promocodes'), event_id)
-          url = build_url(url)
-          response = RestClient.get(url, get_headers())
-
-          promocodes = []
-          JSON.parse(response.body).each do |promocode|
-            promocodes << Components::Promocode.create(promocode)
-          end
-
-          promocodes
-        end
-
-
-        # Get an individual promocode
-        # @param [Integer] event_id - id of event to retrieve item for
-        # @param [Integer] promocode_id - id of item to be retrieved
-        # @return [Promocode]
-        def get_promocode(event_id, promocode_id)
-          url = Util::Config.get('endpoints.base_url') + 
-                sprintf(Util::Config.get('endpoints.event_promocode'), event_id, promocode_id)
-          url = build_url(url)
-          response = RestClient.get(url, get_headers())
-          Components::Promocode.create(JSON.parse(response.body))
-        end
-
-
-        # Create a new promocode for an event
-        # @param [Integer] event_id - id of event to be associated with the promocode
-        # @param [Promocode] promocode - promocode to be created
-        # @return [Promocode]
-        def add_promocode(event_id, promocode)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.event_promocodes'), event_id)
-          url = build_url(url)
-          payload = promocode.to_json
-          response = RestClient.post(url, payload, get_headers())
-          Components::Promocode.create(JSON.parse(response.body))
-        end
-
-
-        # Delete a specific promocode for an event
-        # @param [Integer] event_id - id of event to delete a promocode for
-        # @param [Integer] promocode_id - id of promocode to be deleted
-        # @return [Boolean]
-        def delete_promocode(event_id, promocode_id)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.event_promocode'), event_id, promocode_id)
-          url = build_url(url)
-          response = RestClient.delete(url, get_headers())
-          response.code == 204
-        end
-
-
-        # Update a specific promocode for an event
-        # @param [Integer] event_id - id of event associated with the promocode
-        # @param [Promocode] promocode - promocode to be updated
-        # @return [Promocode]
-        def update_promocode(event_id, promocode)
-          url = Util::Config.get('endpoints.base_url') +
-                sprintf(Util::Config.get('endpoints.event_promocode'), event_id, promocode.id)
-          url = build_url(url)
-          payload = promocode.to_json
-          response = RestClient.put(url, payload, get_headers())
-          Components::Promocode.create(JSON.parse(response.body))
-        end
-
+      # Create a new event
+      # @param [Event] event - Event to be created
+      # @return [Event]
+      def add_event(event)
+        url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.events')
+        url = build_url(url)
+        payload = event.to_json
+        response = RestClient.post(url, payload, get_headers())
+        Components::Event.create(JSON.parse(response.body))
       end
+
+
+      # Get a set of events
+      # @param [Hash] opts query parameters to be appended to the request
+      # @option opts [String] status email campaigns status of DRAFT, RUNNING, SENT, SCHEDULED.
+      # @option opts [String] modified_since ISO-8601 date string to return campaigns modified since then.
+      # @option opts [Integer] limit number of campaigns to return, 1 to 50.
+      # @return [ResultSet<Event>]
+      def get_events(opts = {})
+        url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.events')
+        url = build_url(url, opts)
+
+        response = RestClient.get(url, get_headers())
+        body = JSON.parse(response.body)
+
+        events = body['results'].collect do |event|
+          Components::Event.create_summary(event)
+        end
+
+        Components::ResultSet.new(events, body['meta'])
+      end
+
+
+      # Get event details for a specific event
+      # @param [Integer] event - Valid event id
+      # @return [Event]
+      def get_event(event)
+        event_id = get_id_for(event)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.event'), event_id)
+        url = build_url(url)
+        response = RestClient.get(url, get_headers())
+        Components::Event.create(JSON.parse(response.body))
+      end
+
+
+      # Update a specific EventSpot event
+      # @param [Event] event - Event to be updated
+      # @return [Event]
+      def update_event(event)
+        event_id = get_id_for(event)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.event'), event_id)
+        url = build_url(url)
+        payload = event.to_json
+        response = RestClient.put(url, payload, get_headers())
+        Components::Event.create(JSON.parse(response.body))
+      end
+
+
+      # Publish a specific EventSpot event
+      # @param [Event] event - Event to be updated
+      # @return [Event]
+      def publish_event(event)
+        event_id = get_id_for(event)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.event'), event_id)
+        url = build_url(url)
+        payload = [{:op => "REPLACE", :path => "#/status", :value => "ACTIVE"}].to_json
+        response = RestClient.patch(url, payload, get_headers())
+        Components::Event.create(JSON.parse(response.body))
+      end
+
+
+      # Cancel a specific EventSpot event
+      # @param [Event] event - Event to be updated
+      # @return [Event]
+      def cancel_event(event)
+        event_id = get_id_for(event)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.event'), event_id)
+        url = build_url(url)
+        payload = [{ :op => "REPLACE", :path => "#/status", :value => "CANCELLED" }].to_json
+        response = RestClient.patch(url, payload, get_headers())
+        Components::Event.create(JSON.parse(response.body))
+      end
+
+
+      # Create a new event fee
+      # @param [Integer] event - Valid event id
+      # @param [EventFee] fee - Event fee to be created
+      # @return [EventFee]
+      def add_fee(event, fee)
+        event_id = get_id_for(event)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.event_fees'), event_id)
+        url = build_url(url)
+        payload = fee.to_json
+        response = RestClient.post(url, payload, get_headers())
+        Components::EventFee.create(JSON.parse(response.body))
+      end
+
+
+      # Get an array of event fees
+      # @param [Integer] event - Valid event id
+      # @return [Array<EventFee>]
+      def get_fees(event)
+        event_id = get_id_for(event)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.event_fees'), event_id)
+        url = build_url(url)
+
+        response = RestClient.get(url, get_headers())
+        body = JSON.parse(response.body)
+        
+        fees = body.collect do |fee|
+          Components::EventFee.create(fee)
+        end
+      end
+
+
+      # Get an individual event fee
+      # @param [Integer] event - Valid event id
+      # @param [Integer] fee - Valid fee id
+      # @return [EventFee]
+      def get_fee(event, fee)
+        event_id  = get_id_for(event)
+        fee_id    = get_id_for(fee)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.event_fee'), event_id, fee_id)
+        url = build_url(url)
+
+        response = RestClient.get(url, get_headers())
+       fee = Components::EventFee.create(JSON.parse(response.body))
+      end
+
+
+      # Update an individual event fee
+      # @param [Integer] event - Valid event id
+      # @param [Integer] fee - Valid fee id
+      # @return [EventFee]
+      def update_fee(event, fee)
+        event_id  = get_id_for(event)
+        if fee.kind_of?(ConstantContact::Components::EventFee)
+          fee_id = fee.id
+        elsif fee.kind_of?(Hash)
+          fee_id = fee['id']
+        else
+          raise ArgumentError.new "Fee must be a Hash or ConstantContact::Components::Fee"
+        end
+
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.event_fee'), event_id, fee_id)
+        url = build_url(url)
+        payload = fee.to_json
+
+        response = RestClient.put(url, payload, get_headers())
+       fee = Components::EventFee.create(JSON.parse(response.body))
+      end
+
+
+      # Delete an individual event fee
+      # @param [Integer] event - Valid event id
+      # @param [Integer] fee - Valid fee id
+      # @return [Boolean]
+      def delete_fee(event, fee)
+        event_id  = get_id_for(event)
+        fee_id    = get_id_for(fee)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.event_fee'), event_id, fee_id)
+        url = build_url(url)
+
+        response = RestClient.delete(url, get_headers())
+        response.code == 204
+      end
+
+
+      # Get a set of event registrants
+      # @param [Integer] event - Valid event id
+      # @return [ResultSet<Registrant>]
+      def get_registrants(event)
+        event_id  = event.kind_of?(ConstantContact::Components::Event) ? event.id : event
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.event_registrants'), event_id)
+        url = build_url(url)
+
+        response = RestClient.get(url, get_headers())
+        body = JSON.parse(response.body)
+
+        registrants = body['results'].collect do |registrant|
+          Components::Registrant.create(registrant)
+        end
+
+        Components::ResultSet.new(registrants, body['meta'])
+      end
+
+
+      # Get an individual event registant
+      # @param [Integer] event - Valid event id
+      # @param [Integer] registrant - Valid fee id
+      # @return [Registrant]
+      def get_registrant(event, registrant)
+        event_id      = get_id_for(event)
+        registrant_id  = get_id_for(registrant)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.event_registrant'), event_id, registrant_id)
+        url = build_url(url)
+
+        response = RestClient.get(url, get_headers())
+        Components::Registrant.create(JSON.parse(response.body))
+      end
+
+
+      # Get an array of event items for an individual event
+      # @param [Integer] event_id - event id to retrieve items for
+      # @return [Array<EventItem>]
+      def get_event_items(event_id)
+        url = Util::Config.get('endpoints.base_url') + 
+              sprintf(Util::Config.get('endpoints.event_items'), event_id)
+        url = build_url(url)
+        response = RestClient.get(url, get_headers())
+
+        event_items = []
+        JSON.parse(response.body).each do |event_item|
+          event_items << Components::EventItem.create(event_item)
+        end
+
+        event_items
+      end
+
+
+      # Get an individual event item
+      # @param [Integer] event_id - id of event to retrieve item for
+      # @param [Integer] item_id - id of item to be retrieved
+      # @return [EventItem]
+      def get_event_item(event_id, item_id)
+        url = Util::Config.get('endpoints.base_url') + 
+              sprintf(Util::Config.get('endpoints.event_item'), event_id, item_id)
+        url = build_url(url)
+        response = RestClient.get(url, get_headers())
+        Components::EventItem.create(JSON.parse(response.body))
+      end
+
+
+      # Create a new event item for an event
+      # @param [Integer] event_id - id of event to be associated with the event item
+      # @param [EventItem] event_item - event item to be created
+      # @return [EventItem]
+      def add_event_item(event_id, event_item)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.event_items'), event_id)
+        url = build_url(url)
+        payload = event_item.to_json
+        response = RestClient.post(url, payload, get_headers())
+        Components::EventItem.create(JSON.parse(response.body))
+      end
+
+
+      # Delete a specific event item for an event
+      # @param [Integer] event_id - id of event to delete an event item for
+      # @param [Integer] item_id - id of event item to be deleted
+      # @return [Boolean]
+      def delete_event_item(event_id, item_id)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.event_item'), event_id, item_id)
+        url = build_url(url)
+        response = RestClient.delete(url, get_headers())
+        response.code == 204
+      end
+
+
+      # Update a specific event item for an event
+      # @param [Integer] event_id - id of event associated with the event item
+      # @param [EventItem] event_item - event item to be updated
+      # @return [EventItem]
+      def update_event_item(event_id, event_item)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.event_item'), event_id, event_item.id)
+        url = build_url(url)
+        payload = event_item.to_json
+        response = RestClient.put(url, payload, get_headers())
+        Components::EventItem.create(JSON.parse(response.body))
+      end
+
+
+      # Get an array of attributes for an individual event item
+      # @param [Integer] event_id - event id to retrieve item for
+      # @param [Integer] item_id - event item id to retrieve attributes for
+      # @return [Array<EventItemAttribute>]
+      def get_event_item_attributes(event_id, item_id)
+        url = Util::Config.get('endpoints.base_url') + 
+              sprintf(Util::Config.get('endpoints.event_item_attributes'), event_id, item_id)
+        url = build_url(url)
+        response = RestClient.get(url, get_headers())
+
+        event_item_attributes = []
+        JSON.parse(response.body).each do |event_item_attribute|
+          event_item_attributes << Components::EventItemAttribute.create(event_item_attribute)
+        end
+
+        event_item_attributes
+      end
+
+
+      # Get an individual event item attribute
+      # @param [Integer] event_id - id of event to retrieve item for
+      # @param [Integer] item_id - id of item to retrieve attribute for
+      # @param [Integer] attribute_id - id of attribute to be retrieved
+      # @return [EventItemAttribute]
+      def get_event_item_attribute(event_id, item_id, attribute_id)
+        url = Util::Config.get('endpoints.base_url') + 
+              sprintf(Util::Config.get('endpoints.event_item_attribute'), event_id, item_id, attribute_id)
+        url = build_url(url)
+        response = RestClient.get(url, get_headers())
+        Components::EventItemAttribute.create(JSON.parse(response.body))
+      end
+
+
+      # Create a new event item attribute for an event item
+      # @param [Integer] event_id - id of event to be associated with the event item attribute
+      # @param [Integer] item_id - id of event item to be associated with the event item attribute
+      # @param [EventItemAttribute] event_item_attribute - event item attribute to be created
+      # @return [EventItemAttribute]
+      def add_event_item_attribute(event_id, item_id, event_item_attribute)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.event_item_attributes'), event_id, item_id)
+        url = build_url(url)
+        payload = event_item_attribute.to_json
+        response = RestClient.post(url, payload, get_headers())
+        Components::EventItemAttribute.create(JSON.parse(response.body))
+      end
+
+
+      # Delete a specific event item for an event
+      # @param [Integer] event_id - id of event to delete an event item attribute for
+      # @param [Integer] item_id - id of event item to delete an event item attribute for
+      # @param [Integer] attribute_id - id of attribute to be deleted
+      # @return [Boolean]
+      def delete_event_item_attribute(event_id, item_id, attribute_id)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.event_item_attribute'), event_id, item_id, attribute_id)
+        url = build_url(url)
+        response = RestClient.delete(url, get_headers())
+        response.code == 204
+      end
+
+
+      # Update a specific event item attribute for an event item
+      # @param [Integer] event_id - id of event associated with the event item
+      # @param [Integer] item_id - id of event item associated with the event item attribute
+      # @param [EventItemAttribute] event_item_attribute - event item to be updated
+      # @return [EventItemAttribute]
+      def update_event_item_attribute(event_id, item_id, event_item_attribute)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.event_item'), event_id, item_id, event_item_attribute.id)
+        url = build_url(url)
+        payload = event_item_attribute.to_json
+        response = RestClient.put(url, payload, get_headers())
+        Components::EventItemAttribute.create(JSON.parse(response.body))
+      end
+
+
+      # Get an array of promocodes for an individual event
+      # @param [Integer] event_id - event id to retrieve promocodes for
+      # @return [Array<Promocode>]
+      def get_promocodes(event_id)
+        url = Util::Config.get('endpoints.base_url') + 
+              sprintf(Util::Config.get('endpoints.event_promocodes'), event_id)
+        url = build_url(url)
+        response = RestClient.get(url, get_headers())
+
+        promocodes = []
+        JSON.parse(response.body).each do |promocode|
+          promocodes << Components::Promocode.create(promocode)
+        end
+
+        promocodes
+      end
+
+
+      # Get an individual promocode
+      # @param [Integer] event_id - id of event to retrieve item for
+      # @param [Integer] promocode_id - id of item to be retrieved
+      # @return [Promocode]
+      def get_promocode(event_id, promocode_id)
+        url = Util::Config.get('endpoints.base_url') + 
+              sprintf(Util::Config.get('endpoints.event_promocode'), event_id, promocode_id)
+        url = build_url(url)
+        response = RestClient.get(url, get_headers())
+        Components::Promocode.create(JSON.parse(response.body))
+      end
+
+
+      # Create a new promocode for an event
+      # @param [Integer] event_id - id of event to be associated with the promocode
+      # @param [Promocode] promocode - promocode to be created
+      # @return [Promocode]
+      def add_promocode(event_id, promocode)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.event_promocodes'), event_id)
+        url = build_url(url)
+        payload = promocode.to_json
+        response = RestClient.post(url, payload, get_headers())
+        Components::Promocode.create(JSON.parse(response.body))
+      end
+
+
+      # Delete a specific promocode for an event
+      # @param [Integer] event_id - id of event to delete a promocode for
+      # @param [Integer] promocode_id - id of promocode to be deleted
+      # @return [Boolean]
+      def delete_promocode(event_id, promocode_id)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.event_promocode'), event_id, promocode_id)
+        url = build_url(url)
+        response = RestClient.delete(url, get_headers())
+        response.code == 204
+      end
+
+
+      # Update a specific promocode for an event
+      # @param [Integer] event_id - id of event associated with the promocode
+      # @param [Promocode] promocode - promocode to be updated
+      # @return [Promocode]
+      def update_promocode(event_id, promocode)
+        url = Util::Config.get('endpoints.base_url') +
+              sprintf(Util::Config.get('endpoints.event_promocode'), event_id, promocode.id)
+        url = build_url(url)
+        payload = promocode.to_json
+        response = RestClient.put(url, payload, get_headers())
+        Components::Promocode.create(JSON.parse(response.body))
+      end
+
     end
   end
 end

--- a/lib/constantcontact/services/library_service.rb
+++ b/lib/constantcontact/services/library_service.rb
@@ -7,275 +7,273 @@
 module ConstantContact
   module Services
     class LibraryService < BaseService
-      class << self
 
-        # Retrieve MyLibrary usage information
-        # @return [LibrarySummary]
-        def get_library_info()
-          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.library_info')
+      # Retrieve MyLibrary usage information
+      # @return [LibrarySummary]
+      def get_library_info()
+        url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.library_info')
 
-          response = RestClient.get(url, get_headers())
-          Components::LibrarySummary.create(JSON.parse(response.body).first)
-        end
-
-
-        # Retrieve a list of MyLibrary folders
-        # @param [Hash] params - hash of query parameters and values to append to the request.
-        #     Allowed parameters include:
-        #     sort_by - The method to sort by, valid values are :
-        #         CREATED_DATE - sorts by date folder was added, ascending (earliest to latest)
-        #         CREATED_DATE_DESC - (default) sorts by date folder was added, descending (latest to earliest)
-        #         MODIFIED_DATE - sorts by date folder was last modified, ascending (earliest to latest)
-        #         MODIFIED_DATE_DESC - sorts by date folder was last modified, descending (latest to earliest)
-        #         NAME - sorts alphabetically by folder name, a to z
-        #         NAME_DESC - sorts alphabetically by folder name, z to a
-        #     limit -  Specifies the number of results displayed per page of output, from 1 - 50, default = 50.
-        # @return [ResultSet<LibraryFolder>]
-        def get_library_folders(params)
-          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.library_folders')
-          url = build_url(url, params)
-          response = RestClient.get(url, get_headers())
-          folders = []
-          body = JSON.parse(response.body)
-          body['results'].each do |folder|
-            folders << Components::LibraryFolder.create(folder)
-          end
-          Components::ResultSet.new(folders, body['meta'])
-        end
-
-
-        # Create a new MyLibrary folder
-        # @param [LibraryFolder] folder - MyLibrary folder to be created
-        # @return [LibraryFolder]
-        def add_library_folder(folder)
-          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.library_folders')
-          url = build_url(url)
-          payload = folder.to_json
-          response = RestClient.post(url, payload, get_headers())
-          Components::LibraryFolder.create(JSON.parse(response.body))
-        end
-
-
-        # Retrieve a specific MyLibrary folder using the folder_id path parameter
-        # @param [String] folder_id - The ID for the folder to return
-        # @return [LibraryFolder]
-        def get_library_folder(folder_id)
-          url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.library_folder'), folder_id)
-          url = build_url(url)
-          response = RestClient.get(url, get_headers())
-          Components::LibraryFolder.create(JSON.parse(response.body))
-        end
-
-
-        # Update a specific MyLibrary folder
-        # @param [LibraryFolder] folder - MyLibrary folder to be updated
-        # @return [LibraryFolder]
-        def update_library_folder(folder)
-          url = Util::Config.get('endpoints.base_url') + 
-                sprintf(Util::Config.get('endpoints.library_folder'), folder.id)
-          url = build_url(url)
-          payload = folder.to_json
-          response = RestClient.put(url, payload, get_headers())
-          Components::LibraryFolder.create(JSON.parse(response.body))
-        end
-
-
-        # Delete a MyLibrary folder
-        # @param [String] folder_id - The ID for the MyLibrary folder to delete
-        # @return [Boolean]
-        def delete_library_folder(folder_id)
-          url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.library_folder'), folder_id)
-          url = build_url(url)
-          response = RestClient.delete(url, get_headers())
-          response.code == 204
-        end
-
-
-        # Retrieve all files in the Trash folder
-        # @param [Hash] params - hash of query parameters and values to append to the request.
-        #     Allowed parameters include:
-        #     type - Specifies the type of files to retrieve, valid values are : ALL, IMAGES, or DOCUMENTS
-        #     sort_by - The method to sort by, valid values are :
-        #         ADDED_DATE - sorts by date folder was added, ascending (earliest to latest)
-        #         ADDED_DATE_DESC - (default) sorts by date folder was added, descending (latest to earliest)
-        #         MODIFIED_DATE - sorts by date folder was last modified, ascending (earliest to latest)
-        #         MODIFIED_DATE_DESC - sorts by date folder was last modified, descending (latest to earliest)
-        #         NAME - sorts alphabetically by file name, a to z
-        #         NAME_DESC - sorts alphabetically by file name, z to a
-        #         SIZE - sorts by file size, smallest to largest
-        #         SIZE_DESC - sorts by file size, largest to smallest
-        #         DIMENSION - sorts by file dimensions (hxw), smallest to largest
-        #         DIMENSION_DESC - sorts by file dimensions (hxw), largest to smallest
-        #     limit -  Specifies the number of results displayed per page of output, from 1 - 50, default = 50.
-        # @return [ResultSet<LibraryFile>]
-        def get_library_trash(params)
-          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.library_folder_trash')
-          url = build_url(url, params)
-          response = RestClient.get(url, get_headers())
-          files = []
-          body = JSON.parse(response.body)
-          body['results'].each do |file|
-            files << Components::LibraryFile.create(file)
-          end
-          Components::ResultSet.new(files, body['meta'])
-        end
-
-
-        # Permanently deletes all files in the Trash folder
-        # @return [Boolean]
-        def delete_library_trash()
-          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.library_folder_trash')
-          url = build_url(url)
-          response = RestClient.delete(url, get_headers())
-          response.code == 204
-        end
-
-
-        # Retrieve a collection of MyLibrary files in the Constant Contact account
-        # @param [Hash] params - hash of query parameters and values to append to the request.
-        #     Allowed parameters include:
-        #     type - Specifies the type of files to retrieve, valid values are : ALL, IMAGES, or DOCUMENTS
-        #     source - Specifies to retrieve files from a particular source, valid values are :
-        #         ALL - (default) files from all sources
-        #         MyComputer
-        #         StockImage
-        #         Facebook
-        #         Instagram
-        #         Shutterstock
-        #         Mobile
-        #     limit -  Specifies the number of results displayed per page of output, from 1 - 1000, default = 50.
-        # @return [ResultSet<LibraryFile>]
-        def get_library_files(params = {})
-          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.library_files')
-          url = build_url(url, params)
-          response = RestClient.get(url, get_headers())
-          files = []
-          body = JSON.parse(response.body)
-          body['results'].each do |file|
-            files << Components::LibraryFile.create(file)
-          end
-          Components::ResultSet.new(files, body['meta'])
-        end
-
-
-        # Retrieves all files from a MyLibrary folder specified by the folder_id path parameter
-        # @param [String] folder_id  - Specifies the folder from which to retrieve files
-        # @param [Hash] params - hash of query parameters and values to append to the request.
-        #     Allowed parameters include:
-        #     limit - Specifies the number of results displayed per page of output, from 1 - 50, default = 50.
-        # @return [ResultSet<LibraryFile>]
-        def get_library_files_by_folder(folder_id, params = {})
-          url = Util::Config.get('endpoints.base_url') + 
-                sprintf(Util::Config.get('endpoints.library_files_by_folder'), folder_id)
-          url = build_url(url, params)
-          response = RestClient.get(url, get_headers())
-          files = []
-          body = JSON.parse(response.body)
-          body['results'].each do |file|
-            files << Components::LibraryFile.create(file)
-          end
-          Components::ResultSet.new(files, body['meta'])
-        end
-
-
-        # Retrieve a MyLibrary file using the file_id path parameter
-        # @param [String] file_id - Specifies the MyLibrary file for which to retrieve information
-        # @return [LibraryFile]
-        def get_library_file(file_id)
-          url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.library_file'), file_id)
-          url = build_url(url)
-          response = RestClient.get(url, get_headers())
-          Components::LibraryFile.create(JSON.parse(response.body))
-        end
-
-
-        # Adds a new MyLibrary file using the multipart content-type
-        # @param [String] file_name - The name of the file (ie: dinnerplate-special.jpg)
-        # @param [String] folder_id - Folder id to add the file to
-        # @param [String] description - The description of the file provided by user 
-        # @param [String] source - indicates the source of the original file; 
-        #                          image files can be uploaded from the following sources :
-        #                          MyComputer, StockImage, Facebook - MyLibrary Plus customers only,
-        #                          Instagram - MyLibrary Plus customers only, Shutterstock, Mobile
-        # @param [String] file_type - Specifies the file type, valid values are: JPEG, JPG, GIF, PDF, PNG 
-        # @param [String] contents - The content of the file
-        # @return [LibraryFile]
-        def add_library_file(file_name, folder_id, description, source, file_type, contents)
-          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.library_files')
-          url = build_url(url)
-
-          payload = { :file_name => file_name, :folder_id => folder_id, 
-                      :description => description, :source => source, :file_type => file_type, 
-                      :data => contents, :multipart => true }
-
-          response = RestClient.post(url, payload, get_headers())
-          location = response.headers[:location] || ''
-          location.split('/').last
-        end
-
-
-        # Update information for a specific MyLibrary file
-        # @param [LibraryFile] file - Library File to be updated
-        # @return [LibraryFile]
-        def update_library_file(file)
-          url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.library_file'), file.id)
-          url = build_url(url)
-          payload = file.to_json
-          response = RestClient.put(url, payload, get_headers())
-          Components::LibraryFile.create(JSON.parse(response.body))
-        end
-
-
-        # Delete one or more MyLibrary files specified by the fileId path parameter; 
-        # separate multiple file IDs with a comma. 
-        # Deleted files are moved from their current folder into the system Trash folder, and its status is set to Deleted.
-        # @param [String] file_id - Specifies the MyLibrary file to delete
-        # @return [Boolean]
-        def delete_library_file(file_id)
-          url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.library_file'), file_id)
-          url = build_url(url)
-          response = RestClient.delete(url, get_headers())
-          response.code == 204
-        end
-
-
-        # Retrieve the upload status for one or more MyLibrary files using the file_id path parameter; 
-        # separate multiple file IDs with a comma
-        # @param [String] file_id - Specifies the files for which to retrieve upload status information
-        # @return [Array<UploadStatus>]
-        def get_library_files_upload_status(file_id)
-          url = Util::Config.get('endpoints.base_url') + 
-                sprintf(Util::Config.get('endpoints.library_file_upload_status'), file_id)
-          url = build_url(url)
-          response = RestClient.get(url, get_headers())
-          statuses = []
-          JSON.parse(response.body).each do |status|
-            statuses << Components::UploadStatus.create(status)
-          end
-          statuses
-        end
-
-
-        # Move one or more MyLibrary files to a different folder in the user's account
-        # specify the destination folder using the folder_id path parameter. 
-        # @param [String] folder_id - Specifies the destination MyLibrary folder to which the files will be moved
-        # @param [String] file_id - Specifies the files to move, in a string of comma separated file ids (e.g. 8,9)
-        # @return [Array<MoveResults>]
-        def move_library_files(folder_id, file_id)
-          url = Util::Config.get('endpoints.base_url') + 
-                sprintf(Util::Config.get('endpoints.library_file_move'), folder_id)
-          url = build_url(url)
- 
-          payload = file_id.split(',').map {|id| id.strip}.to_json
-          response = RestClient.put(url, payload, get_headers())
-          results = []
-          JSON.parse(response.body).each do |result|
-            results << Components::MoveResults.create(result)
-          end
-          results
-        end
-
+        response = RestClient.get(url, get_headers())
+        Components::LibrarySummary.create(JSON.parse(response.body).first)
       end
+
+
+      # Retrieve a list of MyLibrary folders
+      # @param [Hash] params - hash of query parameters and values to append to the request.
+      #     Allowed parameters include:
+      #     sort_by - The method to sort by, valid values are :
+      #         CREATED_DATE - sorts by date folder was added, ascending (earliest to latest)
+      #         CREATED_DATE_DESC - (default) sorts by date folder was added, descending (latest to earliest)
+      #         MODIFIED_DATE - sorts by date folder was last modified, ascending (earliest to latest)
+      #         MODIFIED_DATE_DESC - sorts by date folder was last modified, descending (latest to earliest)
+      #         NAME - sorts alphabetically by folder name, a to z
+      #         NAME_DESC - sorts alphabetically by folder name, z to a
+      #     limit -  Specifies the number of results displayed per page of output, from 1 - 50, default = 50.
+      # @return [ResultSet<LibraryFolder>]
+      def get_library_folders(params)
+        url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.library_folders')
+        url = build_url(url, params)
+        response = RestClient.get(url, get_headers())
+        folders = []
+        body = JSON.parse(response.body)
+        body['results'].each do |folder|
+          folders << Components::LibraryFolder.create(folder)
+        end
+        Components::ResultSet.new(folders, body['meta'])
+      end
+
+
+      # Create a new MyLibrary folder
+      # @param [LibraryFolder] folder - MyLibrary folder to be created
+      # @return [LibraryFolder]
+      def add_library_folder(folder)
+        url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.library_folders')
+        url = build_url(url)
+        payload = folder.to_json
+        response = RestClient.post(url, payload, get_headers())
+        Components::LibraryFolder.create(JSON.parse(response.body))
+      end
+
+
+      # Retrieve a specific MyLibrary folder using the folder_id path parameter
+      # @param [String] folder_id - The ID for the folder to return
+      # @return [LibraryFolder]
+      def get_library_folder(folder_id)
+        url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.library_folder'), folder_id)
+        url = build_url(url)
+        response = RestClient.get(url, get_headers())
+        Components::LibraryFolder.create(JSON.parse(response.body))
+      end
+
+
+      # Update a specific MyLibrary folder
+      # @param [LibraryFolder] folder - MyLibrary folder to be updated
+      # @return [LibraryFolder]
+      def update_library_folder(folder)
+        url = Util::Config.get('endpoints.base_url') + 
+              sprintf(Util::Config.get('endpoints.library_folder'), folder.id)
+        url = build_url(url)
+        payload = folder.to_json
+        response = RestClient.put(url, payload, get_headers())
+        Components::LibraryFolder.create(JSON.parse(response.body))
+      end
+
+
+      # Delete a MyLibrary folder
+      # @param [String] folder_id - The ID for the MyLibrary folder to delete
+      # @return [Boolean]
+      def delete_library_folder(folder_id)
+        url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.library_folder'), folder_id)
+        url = build_url(url)
+        response = RestClient.delete(url, get_headers())
+        response.code == 204
+      end
+
+
+      # Retrieve all files in the Trash folder
+      # @param [Hash] params - hash of query parameters and values to append to the request.
+      #     Allowed parameters include:
+      #     type - Specifies the type of files to retrieve, valid values are : ALL, IMAGES, or DOCUMENTS
+      #     sort_by - The method to sort by, valid values are :
+      #         ADDED_DATE - sorts by date folder was added, ascending (earliest to latest)
+      #         ADDED_DATE_DESC - (default) sorts by date folder was added, descending (latest to earliest)
+      #         MODIFIED_DATE - sorts by date folder was last modified, ascending (earliest to latest)
+      #         MODIFIED_DATE_DESC - sorts by date folder was last modified, descending (latest to earliest)
+      #         NAME - sorts alphabetically by file name, a to z
+      #         NAME_DESC - sorts alphabetically by file name, z to a
+      #         SIZE - sorts by file size, smallest to largest
+      #         SIZE_DESC - sorts by file size, largest to smallest
+      #         DIMENSION - sorts by file dimensions (hxw), smallest to largest
+      #         DIMENSION_DESC - sorts by file dimensions (hxw), largest to smallest
+      #     limit -  Specifies the number of results displayed per page of output, from 1 - 50, default = 50.
+      # @return [ResultSet<LibraryFile>]
+      def get_library_trash(params)
+        url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.library_folder_trash')
+        url = build_url(url, params)
+        response = RestClient.get(url, get_headers())
+        files = []
+        body = JSON.parse(response.body)
+        body['results'].each do |file|
+          files << Components::LibraryFile.create(file)
+        end
+        Components::ResultSet.new(files, body['meta'])
+      end
+
+
+      # Permanently deletes all files in the Trash folder
+      # @return [Boolean]
+      def delete_library_trash()
+        url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.library_folder_trash')
+        url = build_url(url)
+        response = RestClient.delete(url, get_headers())
+        response.code == 204
+      end
+
+
+      # Retrieve a collection of MyLibrary files in the Constant Contact account
+      # @param [Hash] params - hash of query parameters and values to append to the request.
+      #     Allowed parameters include:
+      #     type - Specifies the type of files to retrieve, valid values are : ALL, IMAGES, or DOCUMENTS
+      #     source - Specifies to retrieve files from a particular source, valid values are :
+      #         ALL - (default) files from all sources
+      #         MyComputer
+      #         StockImage
+      #         Facebook
+      #         Instagram
+      #         Shutterstock
+      #         Mobile
+      #     limit -  Specifies the number of results displayed per page of output, from 1 - 1000, default = 50.
+      # @return [ResultSet<LibraryFile>]
+      def get_library_files(params = {})
+        url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.library_files')
+        url = build_url(url, params)
+        response = RestClient.get(url, get_headers())
+        files = []
+        body = JSON.parse(response.body)
+        body['results'].each do |file|
+          files << Components::LibraryFile.create(file)
+        end
+        Components::ResultSet.new(files, body['meta'])
+      end
+
+
+      # Retrieves all files from a MyLibrary folder specified by the folder_id path parameter
+      # @param [String] folder_id  - Specifies the folder from which to retrieve files
+      # @param [Hash] params - hash of query parameters and values to append to the request.
+      #     Allowed parameters include:
+      #     limit - Specifies the number of results displayed per page of output, from 1 - 50, default = 50.
+      # @return [ResultSet<LibraryFile>]
+      def get_library_files_by_folder(folder_id, params = {})
+        url = Util::Config.get('endpoints.base_url') + 
+              sprintf(Util::Config.get('endpoints.library_files_by_folder'), folder_id)
+        url = build_url(url, params)
+        response = RestClient.get(url, get_headers())
+        files = []
+        body = JSON.parse(response.body)
+        body['results'].each do |file|
+          files << Components::LibraryFile.create(file)
+        end
+        Components::ResultSet.new(files, body['meta'])
+      end
+
+
+      # Retrieve a MyLibrary file using the file_id path parameter
+      # @param [String] file_id - Specifies the MyLibrary file for which to retrieve information
+      # @return [LibraryFile]
+      def get_library_file(file_id)
+        url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.library_file'), file_id)
+        url = build_url(url)
+        response = RestClient.get(url, get_headers())
+        Components::LibraryFile.create(JSON.parse(response.body))
+      end
+
+
+      # Adds a new MyLibrary file using the multipart content-type
+      # @param [String] file_name - The name of the file (ie: dinnerplate-special.jpg)
+      # @param [String] folder_id - Folder id to add the file to
+      # @param [String] description - The description of the file provided by user 
+      # @param [String] source - indicates the source of the original file; 
+      #                          image files can be uploaded from the following sources :
+      #                          MyComputer, StockImage, Facebook - MyLibrary Plus customers only,
+      #                          Instagram - MyLibrary Plus customers only, Shutterstock, Mobile
+      # @param [String] file_type - Specifies the file type, valid values are: JPEG, JPG, GIF, PDF, PNG 
+      # @param [String] contents - The content of the file
+      # @return [LibraryFile]
+      def add_library_file(file_name, folder_id, description, source, file_type, contents)
+        url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.library_files')
+        url = build_url(url)
+
+        payload = { :file_name => file_name, :folder_id => folder_id, 
+                    :description => description, :source => source, :file_type => file_type, 
+                    :data => contents, :multipart => true }
+
+        response = RestClient.post(url, payload, get_headers())
+        location = response.headers[:location] || ''
+        location.split('/').last
+      end
+
+
+      # Update information for a specific MyLibrary file
+      # @param [LibraryFile] file - Library File to be updated
+      # @return [LibraryFile]
+      def update_library_file(file)
+        url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.library_file'), file.id)
+        url = build_url(url)
+        payload = file.to_json
+        response = RestClient.put(url, payload, get_headers())
+        Components::LibraryFile.create(JSON.parse(response.body))
+      end
+
+
+      # Delete one or more MyLibrary files specified by the fileId path parameter; 
+      # separate multiple file IDs with a comma. 
+      # Deleted files are moved from their current folder into the system Trash folder, and its status is set to Deleted.
+      # @param [String] file_id - Specifies the MyLibrary file to delete
+      # @return [Boolean]
+      def delete_library_file(file_id)
+        url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.library_file'), file_id)
+        url = build_url(url)
+        response = RestClient.delete(url, get_headers())
+        response.code == 204
+      end
+
+
+      # Retrieve the upload status for one or more MyLibrary files using the file_id path parameter; 
+      # separate multiple file IDs with a comma
+      # @param [String] file_id - Specifies the files for which to retrieve upload status information
+      # @return [Array<UploadStatus>]
+      def get_library_files_upload_status(file_id)
+        url = Util::Config.get('endpoints.base_url') + 
+              sprintf(Util::Config.get('endpoints.library_file_upload_status'), file_id)
+        url = build_url(url)
+        response = RestClient.get(url, get_headers())
+        statuses = []
+        JSON.parse(response.body).each do |status|
+          statuses << Components::UploadStatus.create(status)
+        end
+        statuses
+      end
+
+
+      # Move one or more MyLibrary files to a different folder in the user's account
+      # specify the destination folder using the folder_id path parameter. 
+      # @param [String] folder_id - Specifies the destination MyLibrary folder to which the files will be moved
+      # @param [String] file_id - Specifies the files to move, in a string of comma separated file ids (e.g. 8,9)
+      # @return [Array<MoveResults>]
+      def move_library_files(folder_id, file_id)
+        url = Util::Config.get('endpoints.base_url') + 
+              sprintf(Util::Config.get('endpoints.library_file_move'), folder_id)
+        url = build_url(url)
+
+        payload = file_id.split(',').map {|id| id.strip}.to_json
+        response = RestClient.put(url, payload, get_headers())
+        results = []
+        JSON.parse(response.body).each do |result|
+          results << Components::MoveResults.create(result)
+        end
+        results
+      end
+
     end
   end
 end

--- a/lib/constantcontact/services/list_service.rb
+++ b/lib/constantcontact/services/list_service.rb
@@ -7,75 +7,73 @@
 module ConstantContact
   module Services
     class ListService < BaseService
-      class << self
 
-        # Get lists within an account
-        # @param [Hash] params - query parameters to be appended to the request
-        # @return [Array<ContactList>]
-        def get_lists(params = {})
-          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.lists')
-          url = build_url(url, params)
-          response = RestClient.get(url, get_headers())
-          lists = []
-          JSON.parse(response.body).each do |contact|
-            lists << Components::ContactList.create(contact)
-          end
-          lists
+      # Get lists within an account
+      # @param [Hash] params - query parameters to be appended to the request
+      # @return [Array<ContactList>]
+      def get_lists(params = {})
+        url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.lists')
+        url = build_url(url, params)
+        response = RestClient.get(url, get_headers())
+        lists = []
+        JSON.parse(response.body).each do |contact|
+          lists << Components::ContactList.create(contact)
         end
-
-
-        # Add a new list to the Constant Contact account
-        # @param [ContactList] list
-        # @return [ContactList]
-        def add_list(list)
-          url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.lists')
-          url = build_url(url)
-          payload = list.to_json
-          response = RestClient.post(url, payload, get_headers())
-          Components::ContactList.create(JSON.parse(response.body))
-        end
-
-
-        # Update a Contact List
-        # @param [ContactList] list - ContactList to be updated
-        # @return [ContactList]
-        def update_list(list)
-          url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.list'), list.id)
-          url = build_url(url)
-          payload = list.to_json
-          response = RestClient.put(url, payload, get_headers())
-          Components::ContactList.create(JSON.parse(response.body))
-        end
-
-
-        # Get an individual contact list
-        # @param [Integer] list_id - list id
-        # @return [ContactList]
-        def get_list(list_id)
-          url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.list'), list_id)
-          url = build_url(url)
-          response = RestClient.get(url, get_headers())
-          Components::ContactList.create(JSON.parse(response.body))
-        end
-
-
-        # Get all contacts from an individual list
-        # @param [Integer] list_id - list id to retrieve contacts for
-        # @param [Hash] params - query parameters to attach to request
-        # @return [Array<Contact>]
-        def get_contacts_from_list(list_id, params = nil)
-          url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.list_contacts'), list_id)
-          url = build_url(url, params)
-          response = RestClient.get(url, get_headers())
-          contacts = []
-          body = JSON.parse(response.body)
-          body['results'].each do |contact|
-            contacts << Components::Contact.create(contact)
-          end
-          Components::ResultSet.new(contacts, body['meta'])
-        end
-
+        lists
       end
+
+
+      # Add a new list to the Constant Contact account
+      # @param [ContactList] list
+      # @return [ContactList]
+      def add_list(list)
+        url = Util::Config.get('endpoints.base_url') + Util::Config.get('endpoints.lists')
+        url = build_url(url)
+        payload = list.to_json
+        response = RestClient.post(url, payload, get_headers())
+        Components::ContactList.create(JSON.parse(response.body))
+      end
+
+
+      # Update a Contact List
+      # @param [ContactList] list - ContactList to be updated
+      # @return [ContactList]
+      def update_list(list)
+        url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.list'), list.id)
+        url = build_url(url)
+        payload = list.to_json
+        response = RestClient.put(url, payload, get_headers())
+        Components::ContactList.create(JSON.parse(response.body))
+      end
+
+
+      # Get an individual contact list
+      # @param [Integer] list_id - list id
+      # @return [ContactList]
+      def get_list(list_id)
+        url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.list'), list_id)
+        url = build_url(url)
+        response = RestClient.get(url, get_headers())
+        Components::ContactList.create(JSON.parse(response.body))
+      end
+
+
+      # Get all contacts from an individual list
+      # @param [Integer] list_id - list id to retrieve contacts for
+      # @param [Hash] params - query parameters to attach to request
+      # @return [Array<Contact>]
+      def get_contacts_from_list(list_id, params = nil)
+        url = Util::Config.get('endpoints.base_url') + sprintf(Util::Config.get('endpoints.list_contacts'), list_id)
+        url = build_url(url, params)
+        response = RestClient.get(url, get_headers())
+        contacts = []
+        body = JSON.parse(response.body)
+        body['results'].each do |contact|
+          contacts << Components::Contact.create(contact)
+        end
+        Components::ResultSet.new(contacts, body['meta'])
+      end
+
     end
   end
 end

--- a/spec/constantcontact/api_spec.rb
+++ b/spec/constantcontact/api_spec.rb
@@ -30,7 +30,6 @@ describe ConstantContact::Api do
 
   context "with middle-ware configuration" do
     before(:all) do
-      ConstantContact::Services::BaseService.api_key = nil
       ConstantContact::Util::Config.configure do |config|
         config[:auth][:api_key] = "config_api_key"
         config[:auth][:api_secret] = "config_api_secret"
@@ -42,13 +41,12 @@ describe ConstantContact::Api do
       proc.should raise_error(ArgumentError, ConstantContact::Util::Config.get('errors.access_token_missing'))
     end
     it "has the correct implicit api key" do
-      ConstantContact::Services::BaseService.api_key.should == "config_api_key"
+      ConstantContact::Api.new(nil, "access_token").api_key.should == "config_api_key"
     end
   end
 
   context "with middle-ware configuration" do
     before(:all) do
-      ConstantContact::Services::BaseService.api_key = nil
       ConstantContact::Util::Config.configure do |config|
         config[:auth][:api_key] = "config_api_key"
         config[:auth][:api_secret] = "config_api_secret"
@@ -57,7 +55,7 @@ describe ConstantContact::Api do
       ConstantContact::Api.new('explicit_api_key', 'access_token')
     end
     it "has the correct explicit api key" do
-      ConstantContact::Services::BaseService.api_key.should == "explicit_api_key"
+      ConstantContact::Api.new('explicit_api_key', "access_token").api_key.should == "explicit_api_key"
     end
   end
 

--- a/spec/constantcontact/services/account_service_spec.rb
+++ b/spec/constantcontact/services/account_service_spec.rb
@@ -9,6 +9,7 @@ require 'spec_helper'
 describe ConstantContact::Services::AccountService do
   before(:each) do
     @request = double('http request', :user => nil, :password => nil, :url => 'http://example.com', :redirection_history => nil)
+    @client = ConstantContact::Api.new('explicit_api_key', "access_token")
   end
 
   describe "#get_account_info" do
@@ -19,7 +20,7 @@ describe ConstantContact::Services::AccountService do
       response = RestClient::Response.create(json_response, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      result = ConstantContact::Services::AccountService.get_account_info()
+      result = ConstantContact::Services::AccountService.new(@client).get_account_info()
       result.should be_kind_of(ConstantContact::Components::AccountInfo)
       result.website.should eq('http://www.example.com')
       result.organization_addresses.first.should be_kind_of(ConstantContact::Components::AccountAddress)
@@ -36,7 +37,7 @@ describe ConstantContact::Services::AccountService do
       RestClient.stub(:get).and_return(response)
 
       params = {}
-      email_addresses = ConstantContact::Services::AccountService.get_verified_email_addresses(params)
+      email_addresses = ConstantContact::Services::AccountService.new(@client).get_verified_email_addresses(params)
 
       email_addresses.should be_kind_of(Array)
       email_addresses.first.should be_kind_of(ConstantContact::Components::VerifiedEmailAddress)

--- a/spec/constantcontact/services/activity_service_spec.rb
+++ b/spec/constantcontact/services/activity_service_spec.rb
@@ -9,6 +9,7 @@ require 'spec_helper'
 describe ConstantContact::Services::ActivityService do
   before(:each) do
     @request = double('http request', :user => nil, :password => nil, :url => 'http://example.com', :redirection_history => nil)
+    @client = ConstantContact::Api.new('explicit_api_key', "access_token")
   end
 
   describe "#get_activities" do
@@ -19,7 +20,7 @@ describe ConstantContact::Services::ActivityService do
       response = RestClient::Response.create(json_response, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      activities = ConstantContact::Services::ActivityService.get_activities()
+      activities = ConstantContact::Services::ActivityService.new(@client).get_activities()
       activities.first.should be_kind_of(ConstantContact::Components::Activity)
       activities.first.type.should eq('REMOVE_CONTACTS_FROM_LISTS')
     end
@@ -33,7 +34,7 @@ describe ConstantContact::Services::ActivityService do
       response = RestClient::Response.create(json_response, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      activity = ConstantContact::Services::ActivityService.get_activity('a07e1ilbm7shdg6ikeo')
+      activity = ConstantContact::Services::ActivityService.new(@client).get_activity('a07e1ilbm7shdg6ikeo')
       activity.should be_kind_of(ConstantContact::Components::Activity)
       activity.type.should eq('REMOVE_CONTACTS_FROM_LISTS')
     end
@@ -123,7 +124,7 @@ describe ConstantContact::Services::ActivityService do
 
       JSON.parse(json_request).should eq(JSON.parse(JSON.generate(add_contact)))
 
-      activity = ConstantContact::Services::ActivityService.create_add_contacts_activity(add_contact)
+      activity = ConstantContact::Services::ActivityService.new(@client).create_add_contacts_activity(add_contact)
       activity.should be_kind_of(ConstantContact::Components::Activity)
       activity.type.should eq('ADD_CONTACTS')
     end
@@ -139,7 +140,7 @@ describe ConstantContact::Services::ActivityService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:post).and_return(response)
 
-      activity = ConstantContact::Services::ActivityService.create_add_contacts_activity_from_file(
+      activity = ConstantContact::Services::ActivityService.new(@client).create_add_contacts_activity_from_file(
         'contacts.txt', content, lists)
       activity.should be_kind_of(ConstantContact::Components::Activity)
       activity.type.should eq('ADD_CONTACTS')
@@ -159,7 +160,7 @@ describe ConstantContact::Services::ActivityService do
       response = RestClient::Response.create(json_clear_lists, net_http_resp, @request)
       RestClient.stub(:post).and_return(response)
 
-      activity = ConstantContact::Services::ActivityService.add_clear_lists_activity(lists)
+      activity = ConstantContact::Services::ActivityService.new(@client).add_clear_lists_activity(lists)
       activity.should be_kind_of(ConstantContact::Components::Activity)
       activity.type.should eq('CLEAR_CONTACTS_FROM_LISTS')
     end
@@ -175,7 +176,7 @@ describe ConstantContact::Services::ActivityService do
       RestClient.stub(:post).and_return(response)
       email_addresses = ["djellesma@constantcontact.com"]
 
-      activity = ConstantContact::Services::ActivityService.add_remove_contacts_from_lists_activity(
+      activity = ConstantContact::Services::ActivityService.new(@client).add_remove_contacts_from_lists_activity(
         email_addresses, lists)
       activity.should be_kind_of(ConstantContact::Components::Activity)
       activity.type.should eq('REMOVE_CONTACTS_FROM_LISTS')
@@ -192,7 +193,7 @@ describe ConstantContact::Services::ActivityService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:post).and_return(response)
 
-      activity = ConstantContact::Services::ActivityService.add_remove_contacts_from_lists_activity_from_file(
+      activity = ConstantContact::Services::ActivityService.new(@client).add_remove_contacts_from_lists_activity_from_file(
         'contacts.txt', content, lists)
       activity.should be_kind_of(ConstantContact::Components::Activity)
       activity.type.should eq('REMOVE_CONTACTS_FROM_LISTS')
@@ -210,7 +211,7 @@ describe ConstantContact::Services::ActivityService do
 
       export_contacts = ConstantContact::Components::ExportContacts.new(JSON.parse(json_request))
 
-      activity = ConstantContact::Services::ActivityService.add_export_contacts_activity(export_contacts)
+      activity = ConstantContact::Services::ActivityService.new(@client).add_export_contacts_activity(export_contacts)
       activity.should be_kind_of(ConstantContact::Components::Activity)
       activity.type.should eq('EXPORT_CONTACTS')
     end
@@ -237,7 +238,7 @@ describe ConstantContact::Services::ActivityService do
         end
       end
 
-      activity = ConstantContact::Services::ActivityService.add_remove_contacts_from_lists_activity(email_addresses, lists)
+      activity = ConstantContact::Services::ActivityService.new(@client).add_remove_contacts_from_lists_activity(email_addresses, lists)
       activity.type.should eq('REMOVE_CONTACTS_FROM_LISTS')
     end
   end

--- a/spec/constantcontact/services/base_service_spec.rb
+++ b/spec/constantcontact/services/base_service_spec.rb
@@ -7,11 +7,13 @@
 require 'spec_helper'
 
 describe ConstantContact::Services::BaseService do
+  before(:each) { 
+    @client = ConstantContact::Api.new('api key', "foo")
+  }
   describe "#get_headers" do
     it "gets a hash of headers" do
       token = 'foo'
-      ConstantContact::Services::BaseService.access_token = token
-      headers = ConstantContact::Services::BaseService.send(:get_headers)
+      headers = ConstantContact::Services::BaseService.new(@client).send(:get_headers)
 
       expect(headers).to be_a Hash
       expect(headers[:content_type]).to be_a String
@@ -30,7 +32,7 @@ describe ConstantContact::Services::BaseService do
 
   describe "#build_url" do
     it "combines all the given parameters into the url" do
-      components = ConstantContact::Services::BaseService.send(:build_url, "http://testing.com", :arg1 => 'abc', :arg2 => 123).split('&')
+      components = ConstantContact::Services::BaseService.new(@client).send(:build_url, "http://testing.com", :arg1 => 'abc', :arg2 => 123).split('&')
       expect(components[0]).to eq('http://testing.com?api_key=api+key')
       expect(components.length).to eq(3)
       expect(components.include?('arg1=abc')).to be_true
@@ -38,12 +40,12 @@ describe ConstantContact::Services::BaseService do
     end
 
     it "does not parse the next param when not in next_link format" do
-      url = ConstantContact::Services::BaseService.send(:build_url, "http://testing.com", :next => "abcdef")
+      url = ConstantContact::Services::BaseService.new(@client).send(:build_url, "http://testing.com", :next => "abcdef")
       expect(url).to eq('http://testing.com?api_key=api+key&next=abcdef')
     end
 
     it "parses next id from next param given in next_link format" do
-      url = ConstantContact::Services::BaseService.send(:build_url, "http://testing.com", :next => "/some/path?next=abcdefg")
+      url = ConstantContact::Services::BaseService.new(@client).send(:build_url, "http://testing.com", :next => "/some/path?next=abcdefg")
       expect(url).to eq('http://testing.com?api_key=api+key&next=abcdefg')
     end
   end

--- a/spec/constantcontact/services/campaign_schedule_service_spec.rb
+++ b/spec/constantcontact/services/campaign_schedule_service_spec.rb
@@ -9,6 +9,7 @@ require 'spec_helper'
 describe ConstantContact::Services::CampaignScheduleService do
   before(:each) do
     @request = double('http request', :user => nil, :password => nil, :url => 'http://example.com', :redirection_history => nil)
+    @client = ConstantContact::Api.new('explicit_api_key', "access_token")
   end
 
   describe "#add_schedule" do
@@ -21,7 +22,7 @@ describe ConstantContact::Services::CampaignScheduleService do
       RestClient.stub(:post).and_return(response)
       new_schedule = ConstantContact::Components::Schedule.create(JSON.parse(json))
 
-      schedule = ConstantContact::Services::CampaignScheduleService.add_schedule(
+      schedule = ConstantContact::Services::CampaignScheduleService.new(@client).add_schedule(
         campaign_id, new_schedule)
       schedule.should be_kind_of(ConstantContact::Components::Schedule)
       schedule.scheduled_date.should eq('2013-05-10T11:07:43.626Z')
@@ -37,7 +38,7 @@ describe ConstantContact::Services::CampaignScheduleService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      schedules = ConstantContact::Services::CampaignScheduleService.get_schedules(
+      schedules = ConstantContact::Services::CampaignScheduleService.new(@client).get_schedules(
         campaign_id)
       schedules.first.should be_kind_of(ConstantContact::Components::Schedule)
       schedules.first.scheduled_date.should eq('2012-12-16T11:07:43.626Z')
@@ -55,7 +56,7 @@ describe ConstantContact::Services::CampaignScheduleService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      schedule = ConstantContact::Services::CampaignScheduleService.get_schedule(
+      schedule = ConstantContact::Services::CampaignScheduleService.new(@client).get_schedule(
         campaign_id, schedule_id)
       schedule.should be_kind_of(ConstantContact::Components::Schedule)
       schedule.scheduled_date.should eq('2013-05-10T11:07:43.626Z')
@@ -71,7 +72,7 @@ describe ConstantContact::Services::CampaignScheduleService do
       response = RestClient::Response.create('', net_http_resp, @request)
       RestClient.stub(:delete).and_return(response)
 
-      result = ConstantContact::Services::CampaignScheduleService.delete_schedule(
+      result = ConstantContact::Services::CampaignScheduleService.new(@client).delete_schedule(
         campaign_id, schedule_id)
       result.should be_true
     end
@@ -87,7 +88,7 @@ describe ConstantContact::Services::CampaignScheduleService do
       RestClient.stub(:put).and_return(response)
       schedule = ConstantContact::Components::Schedule.create(JSON.parse(json))
 
-      result = ConstantContact::Services::CampaignScheduleService.update_schedule(
+      result = ConstantContact::Services::CampaignScheduleService.new(@client).update_schedule(
         campaign_id, schedule)
       result.should be_kind_of(ConstantContact::Components::Schedule)
       result.scheduled_date.should eq('2013-05-10T11:07:43.626Z')
@@ -105,7 +106,7 @@ describe ConstantContact::Services::CampaignScheduleService do
       RestClient.stub(:post).and_return(response)
       test_send = ConstantContact::Components::TestSend.create(JSON.parse(json_request))
 
-      result = ConstantContact::Services::CampaignScheduleService.send_test(
+      result = ConstantContact::Services::CampaignScheduleService.new(@client).send_test(
         campaign_id, test_send)
       result.should be_kind_of(ConstantContact::Components::TestSend)
       result.personal_message.should eq('This is a test send of the email campaign message.')

--- a/spec/constantcontact/services/campaign_tracking_service_spec.rb
+++ b/spec/constantcontact/services/campaign_tracking_service_spec.rb
@@ -9,6 +9,7 @@ require 'spec_helper'
 describe ConstantContact::Services::CampaignTrackingService do
   before(:each) do
     @request = double('http request', :user => nil, :password => nil, :url => 'http://example.com', :redirection_history => nil)
+    @client = ConstantContact::Api.new('explicit_api_key', "access_token")
   end
 
   describe "#get_bounces" do
@@ -21,7 +22,7 @@ describe ConstantContact::Services::CampaignTrackingService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      set = ConstantContact::Services::CampaignTrackingService.get_bounces(campaign_id, params)
+      set = ConstantContact::Services::CampaignTrackingService.new(@client).get_bounces(campaign_id, params)
       set.should be_kind_of(ConstantContact::Components::ResultSet)
       set.results.first.should be_kind_of(ConstantContact::Components::BounceActivity)
       set.results.first.activity_type.should eq('EMAIL_BOUNCE')
@@ -38,7 +39,7 @@ describe ConstantContact::Services::CampaignTrackingService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      set = ConstantContact::Services::CampaignTrackingService.get_clicks(campaign_id, params)
+      set = ConstantContact::Services::CampaignTrackingService.new(@client).get_clicks(campaign_id, params)
       set.should be_kind_of(ConstantContact::Components::ResultSet)
       set.results.first.should be_kind_of(ConstantContact::Components::ClickActivity)
       set.results.first.activity_type.should eq('EMAIL_CLICK')
@@ -55,7 +56,7 @@ describe ConstantContact::Services::CampaignTrackingService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      set = ConstantContact::Services::CampaignTrackingService.get_forwards(campaign_id, params)
+      set = ConstantContact::Services::CampaignTrackingService.new(@client).get_forwards(campaign_id, params)
       set.should be_kind_of(ConstantContact::Components::ResultSet)
       set.results.first.should be_kind_of(ConstantContact::Components::ForwardActivity)
       set.results.first.activity_type.should eq('EMAIL_FORWARD')
@@ -72,7 +73,7 @@ describe ConstantContact::Services::CampaignTrackingService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      set = ConstantContact::Services::CampaignTrackingService.get_opens(campaign_id, params)
+      set = ConstantContact::Services::CampaignTrackingService.new(@client).get_opens(campaign_id, params)
       set.should be_kind_of(ConstantContact::Components::ResultSet)
       set.results.first.should be_kind_of(ConstantContact::Components::OpenActivity)
       set.results.first.activity_type.should eq('EMAIL_OPEN')
@@ -89,7 +90,7 @@ describe ConstantContact::Services::CampaignTrackingService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      set = ConstantContact::Services::CampaignTrackingService.get_sends(campaign_id, params)
+      set = ConstantContact::Services::CampaignTrackingService.new(@client).get_sends(campaign_id, params)
       set.should be_kind_of(ConstantContact::Components::ResultSet)
       set.results.first.should be_kind_of(ConstantContact::Components::SendActivity)
       set.results.first.activity_type.should eq('EMAIL_SEND')
@@ -106,7 +107,7 @@ describe ConstantContact::Services::CampaignTrackingService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      set = ConstantContact::Services::CampaignTrackingService.get_unsubscribes(campaign_id, params)
+      set = ConstantContact::Services::CampaignTrackingService.new(@client).get_unsubscribes(campaign_id, params)
       set.should be_kind_of(ConstantContact::Components::ResultSet)
       set.results.first.should be_kind_of(ConstantContact::Components::UnsubscribeActivity)
       set.results.first.activity_type.should eq('EMAIL_UNSUBSCRIBE')
@@ -122,7 +123,7 @@ describe ConstantContact::Services::CampaignTrackingService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      summary = ConstantContact::Services::CampaignTrackingService.get_summary(campaign_id)
+      summary = ConstantContact::Services::CampaignTrackingService.new(@client).get_summary(campaign_id)
       summary.should be_kind_of(ConstantContact::Components::TrackingSummary)
       summary.sends.should eq(15)
     end

--- a/spec/constantcontact/services/contact_service_spec.rb
+++ b/spec/constantcontact/services/contact_service_spec.rb
@@ -9,6 +9,7 @@ require 'spec_helper'
 describe ConstantContact::Services::ContactService do
   before(:each) do
     @request = double('http request', :user => nil, :password => nil, :url => 'http://example.com', :redirection_history => nil)
+    @client = ConstantContact::Api.new('explicit_api_key', "access_token")
   end
 
   describe "#get_contacts" do
@@ -18,7 +19,7 @@ describe ConstantContact::Services::ContactService do
 
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
-      contacts = ConstantContact::Services::ContactService.get_contacts()
+      contacts = ConstantContact::Services::ContactService.new(@client).get_contacts()
       contact = contacts.results[0]
 
       contacts.should be_kind_of(ConstantContact::Components::ResultSet)
@@ -33,7 +34,7 @@ describe ConstantContact::Services::ContactService do
 
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
-      contact = ConstantContact::Services::ContactService.get_contact(1)
+      contact = ConstantContact::Services::ContactService.new(@client).get_contact(1)
 
       contact.should be_kind_of(ConstantContact::Components::Contact)
     end
@@ -47,7 +48,7 @@ describe ConstantContact::Services::ContactService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:post).and_return(response)
       new_contact = ConstantContact::Components::Contact.create(JSON.parse(json))
-      contact = ConstantContact::Services::ContactService.add_contact(new_contact)
+      contact = ConstantContact::Services::ContactService.new(@client).add_contact(new_contact)
 
       contact.should be_kind_of(ConstantContact::Components::Contact)
       contact.status.should eq('ACTIVE')
@@ -62,7 +63,7 @@ describe ConstantContact::Services::ContactService do
       response = RestClient::Response.create('', net_http_resp, @request)
       RestClient.stub(:delete).and_return(response)
 
-      result = ConstantContact::Services::ContactService.delete_contact(contact_id)
+      result = ConstantContact::Services::ContactService.new(@client).delete_contact(contact_id)
       result.should be_true
     end
   end
@@ -75,7 +76,7 @@ describe ConstantContact::Services::ContactService do
       response = RestClient::Response.create('', net_http_resp, @request)
       RestClient.stub(:delete).and_return(response)
 
-      result = ConstantContact::Services::ContactService.delete_contact_from_lists(contact_id)
+      result = ConstantContact::Services::ContactService.new(@client).delete_contact_from_lists(contact_id)
       result.should be_true
     end
   end
@@ -89,7 +90,7 @@ describe ConstantContact::Services::ContactService do
       response = RestClient::Response.create('', net_http_resp, @request)
       RestClient.stub(:delete).and_return(response)
 
-      result = ConstantContact::Services::ContactService.delete_contact_from_list(contact_id, list_id)
+      result = ConstantContact::Services::ContactService.new(@client).delete_contact_from_list(contact_id, list_id)
       result.should be_true
     end
   end
@@ -102,7 +103,7 @@ describe ConstantContact::Services::ContactService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:put).and_return(response)
       contact = ConstantContact::Components::Contact.create(JSON.parse(json))
-      result = ConstantContact::Services::ContactService.update_contact(contact)
+      result = ConstantContact::Services::ContactService.new(@client).update_contact(contact)
 
       result.should be_kind_of(ConstantContact::Components::Contact)
       result.status.should eq('ACTIVE')

--- a/spec/constantcontact/services/contact_tracking_service_spec.rb
+++ b/spec/constantcontact/services/contact_tracking_service_spec.rb
@@ -9,6 +9,7 @@ require 'spec_helper'
 describe ConstantContact::Services::ContactTrackingService do
   before(:each) do
     @request = double('http request', :user => nil, :password => nil, :url => 'http://example.com', :redirection_history => nil)
+    @client = ConstantContact::Api.new('explicit_api_key', "access_token")
   end
 
   describe "#get_bounces" do
@@ -21,7 +22,7 @@ describe ConstantContact::Services::ContactTrackingService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      set = ConstantContact::Services::ContactTrackingService.get_bounces(contact_id, params)
+      set = ConstantContact::Services::ContactTrackingService.new(@client).get_bounces(contact_id, params)
       set.should be_kind_of(ConstantContact::Components::ResultSet)
       set.results.first.should be_kind_of(ConstantContact::Components::BounceActivity)
       set.results.first.activity_type.should eq('EMAIL_BOUNCE')
@@ -38,7 +39,7 @@ describe ConstantContact::Services::ContactTrackingService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      set = ConstantContact::Services::ContactTrackingService.get_clicks(contact_id, params)
+      set = ConstantContact::Services::ContactTrackingService.new(@client).get_clicks(contact_id, params)
       set.should be_kind_of(ConstantContact::Components::ResultSet)
       set.results.first.should be_kind_of(ConstantContact::Components::ClickActivity)
       set.results.first.activity_type.should eq('EMAIL_CLICK')
@@ -55,7 +56,7 @@ describe ConstantContact::Services::ContactTrackingService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      set = ConstantContact::Services::ContactTrackingService.get_forwards(contact_id, params)
+      set = ConstantContact::Services::ContactTrackingService.new(@client).get_forwards(contact_id, params)
       set.should be_kind_of(ConstantContact::Components::ResultSet)
       set.results.first.should be_kind_of(ConstantContact::Components::ForwardActivity)
       set.results.first.activity_type.should eq('EMAIL_FORWARD')
@@ -72,7 +73,7 @@ describe ConstantContact::Services::ContactTrackingService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      set = ConstantContact::Services::ContactTrackingService.get_opens(contact_id, params)
+      set = ConstantContact::Services::ContactTrackingService.new(@client).get_opens(contact_id, params)
       set.should be_kind_of(ConstantContact::Components::ResultSet)
       set.results.first.should be_kind_of(ConstantContact::Components::OpenActivity)
       set.results.first.activity_type.should eq('EMAIL_OPEN')
@@ -89,7 +90,7 @@ describe ConstantContact::Services::ContactTrackingService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      set = ConstantContact::Services::ContactTrackingService.get_sends(contact_id, params)
+      set = ConstantContact::Services::ContactTrackingService.new(@client).get_sends(contact_id, params)
       set.should be_kind_of(ConstantContact::Components::ResultSet)
       set.results.first.should be_kind_of(ConstantContact::Components::SendActivity)
       set.results.first.activity_type.should eq('EMAIL_SEND')
@@ -106,7 +107,7 @@ describe ConstantContact::Services::ContactTrackingService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      set = ConstantContact::Services::ContactTrackingService.get_unsubscribes(contact_id, params)
+      set = ConstantContact::Services::ContactTrackingService.new(@client).get_unsubscribes(contact_id, params)
       set.should be_kind_of(ConstantContact::Components::ResultSet)
       set.results.first.should be_kind_of(ConstantContact::Components::UnsubscribeActivity)
       set.results.first.activity_type.should eq('EMAIL_UNSUBSCRIBE')
@@ -122,7 +123,7 @@ describe ConstantContact::Services::ContactTrackingService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      summary = ConstantContact::Services::CampaignTrackingService.get_summary(contact_id)
+      summary = ConstantContact::Services::CampaignTrackingService.new(@client).get_summary(contact_id)
       summary.should be_kind_of(ConstantContact::Components::TrackingSummary)
       summary.sends.should eq(15)
     end

--- a/spec/constantcontact/services/email_marketing_spec.rb
+++ b/spec/constantcontact/services/email_marketing_spec.rb
@@ -9,6 +9,7 @@ require 'spec_helper'
 describe ConstantContact::Services::EmailMarketingService do
   before(:each) do
     @request = double('http request', :user => nil, :password => nil, :url => 'http://example.com', :redirection_history => nil)
+    @client = ConstantContact::Api.new('explicit_api_key', "access_token")
   end
 
   describe "#get_campaigns" do
@@ -19,7 +20,7 @@ describe ConstantContact::Services::EmailMarketingService do
       response = RestClient::Response.create(json_response, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      campaigns = ConstantContact::Services::EmailMarketingService.get_campaigns()
+      campaigns = ConstantContact::Services::EmailMarketingService.new(@client).get_campaigns()
       campaigns.should be_kind_of(ConstantContact::Components::ResultSet)
       campaigns.results.first.should be_kind_of(ConstantContact::Components::Campaign)
       campaigns.results.first.name.should eq('1357157252225')
@@ -34,7 +35,7 @@ describe ConstantContact::Services::EmailMarketingService do
       response = RestClient::Response.create(json_response, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      campaign = ConstantContact::Services::EmailMarketingService.get_campaign(1)
+      campaign = ConstantContact::Services::EmailMarketingService.new(@client).get_campaign(1)
       campaign.should be_kind_of(ConstantContact::Components::Campaign)
       campaign.name.should eq('Campaign Name')
     end
@@ -48,7 +49,7 @@ describe ConstantContact::Services::EmailMarketingService do
       response = RestClient::Response.create(json_response, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      campaign_preview = ConstantContact::Services::EmailMarketingService.get_campaign_preview(1)
+      campaign_preview = ConstantContact::Services::EmailMarketingService.new(@client).get_campaign_preview(1)
       campaign_preview.should be_kind_of(ConstantContact::Components::CampaignPreview)
       campaign_preview.subject.should eq('Subject Test')
     end
@@ -63,7 +64,7 @@ describe ConstantContact::Services::EmailMarketingService do
       RestClient.stub(:post).and_return(response)
       new_campaign = ConstantContact::Components::Campaign.create(JSON.parse(json))
 
-      campaign = ConstantContact::Services::EmailMarketingService.add_campaign(new_campaign)
+      campaign = ConstantContact::Services::EmailMarketingService.new(@client).add_campaign(new_campaign)
       campaign.should be_kind_of(ConstantContact::Components::Campaign)
       campaign.name.should eq('Campaign Name')
     end
@@ -78,7 +79,7 @@ describe ConstantContact::Services::EmailMarketingService do
       RestClient.stub(:delete).and_return(response)
       campaign = ConstantContact::Components::Campaign.create(JSON.parse(json))
 
-      result = ConstantContact::Services::EmailMarketingService.delete_campaign(campaign)
+      result = ConstantContact::Services::EmailMarketingService.new(@client).delete_campaign(campaign)
       result.should be_true
     end
   end
@@ -92,7 +93,7 @@ describe ConstantContact::Services::EmailMarketingService do
       RestClient.stub(:put).and_return(response)
       campaign = ConstantContact::Components::Campaign.create(JSON.parse(json))
 
-      result = ConstantContact::Services::EmailMarketingService.update_campaign(campaign)
+      result = ConstantContact::Services::EmailMarketingService.new(@client).update_campaign(campaign)
       result.should be_kind_of(ConstantContact::Components::Campaign)
       result.name.should eq('Campaign Name')
     end

--- a/spec/constantcontact/services/event_spot_spec.rb
+++ b/spec/constantcontact/services/event_spot_spec.rb
@@ -9,6 +9,7 @@ require 'spec_helper'
 describe ConstantContact::Services::EventSpotService do
   before(:each) do
     @request = double('http request', :user => nil, :password => nil, :url => 'http://example.com', :redirection_history => nil)
+    @client = ConstantContact::Api.new('explicit_api_key', "access_token")
   end
 
   describe "#get_events" do
@@ -18,7 +19,7 @@ describe ConstantContact::Services::EventSpotService do
 
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
-      events = ConstantContact::Services::EventSpotService.get_events()
+      events = ConstantContact::Services::EventSpotService.new(@client).get_events()
       events.should be_kind_of(ConstantContact::Components::ResultSet)
       events.results.collect{|e| e.should be_kind_of(ConstantContact::Components::Event) }
     end
@@ -31,7 +32,7 @@ describe ConstantContact::Services::EventSpotService do
 
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
-      event = ConstantContact::Services::EventSpotService.get_event(1)
+      event = ConstantContact::Services::EventSpotService.new(@client).get_event(1)
 
       event.should be_kind_of(ConstantContact::Components::Event)
     end
@@ -45,7 +46,7 @@ describe ConstantContact::Services::EventSpotService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:post).and_return(response)
       event = ConstantContact::Components::Event.create(JSON.parse(json))
-      added = ConstantContact::Services::EventSpotService.add_event(event)
+      added = ConstantContact::Services::EventSpotService.new(@client).add_event(event)
 
       added.should respond_to(:id)
       added.id.should_not be_empty
@@ -63,7 +64,7 @@ describe ConstantContact::Services::EventSpotService do
       RestClient.stub(:patch).and_return(response)
       
       event = ConstantContact::Components::Event.create(JSON.parse(json))
-      updated = ConstantContact::Services::EventSpotService.publish_event(event)
+      updated = ConstantContact::Services::EventSpotService.new(@client).publish_event(event)
       updated.should be_kind_of(ConstantContact::Components::Event)
       updated.should respond_to(:status)
       updated.status.should eq("ACTIVE")
@@ -81,7 +82,7 @@ describe ConstantContact::Services::EventSpotService do
       RestClient.stub(:patch).and_return(response)
 
       event = ConstantContact::Components::Event.create(JSON.parse(json))
-      updated = ConstantContact::Services::EventSpotService.cancel_event(event)
+      updated = ConstantContact::Services::EventSpotService.new(@client).cancel_event(event)
       updated.should be_kind_of(ConstantContact::Components::Event)
       updated.should respond_to(:status)
       updated.status.should eq("CANCELLED")
@@ -97,7 +98,7 @@ describe ConstantContact::Services::EventSpotService do
       response = RestClient::Response.create(fees_json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
       event = ConstantContact::Components::Event.create(JSON.parse(event_json))
-      fees = ConstantContact::Services::EventSpotService.get_fees(event)
+      fees = ConstantContact::Services::EventSpotService.new(@client).get_fees(event)
       #fees.should be_kind_of(ConstantContact::Components::ResultSet)
       #fees.results.collect{|f| f.should be_kind_of(ConstantContact::Components::Fee) }
 
@@ -117,7 +118,7 @@ describe ConstantContact::Services::EventSpotService do
 
       event = ConstantContact::Components::Event.create(JSON.parse(event_json))
       fee   = ConstantContact::Components::EventFee.create(JSON.parse(fee_json))
-      retrieved = ConstantContact::Services::EventSpotService.get_fee(event, fee)
+      retrieved = ConstantContact::Services::EventSpotService.new(@client).get_fee(event, fee)
       retrieved.should be_kind_of(ConstantContact::Components::EventFee)
     end
   end
@@ -133,7 +134,7 @@ describe ConstantContact::Services::EventSpotService do
 
       event = ConstantContact::Components::Event.create(JSON.parse(event_json))
       fee   = ConstantContact::Components::EventFee.create(JSON.parse(fee_json))
-      added = ConstantContact::Services::EventSpotService.add_fee(event, fee)
+      added = ConstantContact::Services::EventSpotService.new(@client).add_fee(event, fee)
       added.should be_kind_of(ConstantContact::Components::EventFee)
       added.id.should_not be_empty
     end
@@ -152,7 +153,7 @@ describe ConstantContact::Services::EventSpotService do
 
       event = ConstantContact::Components::Event.create(JSON.parse(event_json))
       fee   = ConstantContact::Components::EventFee.create(JSON.parse(fee_json))
-      updated = ConstantContact::Services::EventSpotService.update_fee(event, fee)
+      updated = ConstantContact::Services::EventSpotService.new(@client).update_fee(event, fee)
       updated.should be_kind_of(ConstantContact::Components::EventFee)
       updated.fee.should_not eq(fee.fee)
       updated.fee.should eq(fee.fee + 1)
@@ -170,7 +171,7 @@ describe ConstantContact::Services::EventSpotService do
 
       event = ConstantContact::Components::Event.create(JSON.parse(event_json))
       fee   = ConstantContact::Components::EventFee.create(JSON.parse(fee_json))
-      ConstantContact::Services::EventSpotService.delete_fee(event, fee).should be_true
+      ConstantContact::Services::EventSpotService.new(@client).delete_fee(event, fee).should be_true
     end
   end
 
@@ -184,7 +185,7 @@ describe ConstantContact::Services::EventSpotService do
       RestClient.stub(:get).and_return(response)
 
       event = ConstantContact::Components::Event.create(JSON.parse(event_json))
-      registrants = ConstantContact::Services::EventSpotService.get_registrants(event)
+      registrants = ConstantContact::Services::EventSpotService.new(@client).get_registrants(event)
       registrants.should be_kind_of(ConstantContact::Components::ResultSet)
       registrants.results.collect{|r| r .should be_kind_of(ConstantContact::Components::Registrant) }
     end
@@ -201,7 +202,7 @@ describe ConstantContact::Services::EventSpotService do
 
       event = ConstantContact::Components::Event.create(JSON.parse(event_json))
       registrant = ConstantContact::Components::Registrant.create(JSON.parse(registrant_json))
-      retrieved = ConstantContact::Services::EventSpotService.get_registrant(event, registrant)
+      retrieved = ConstantContact::Services::EventSpotService.new(@client).get_registrant(event, registrant)
       retrieved.should be_kind_of(ConstantContact::Components::Registrant)
       retrieved.id.should_not be_empty
     end
@@ -215,7 +216,7 @@ describe ConstantContact::Services::EventSpotService do
       response = RestClient::Response.create(json_response, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      results = ConstantContact::Services::EventSpotService.get_event_items(1)
+      results = ConstantContact::Services::EventSpotService.new(@client).get_event_items(1)
       results.should be_kind_of(Array)
       results.first.should be_kind_of(ConstantContact::Components::EventItem)
       results.first.name.should eq('Running Belt')
@@ -230,7 +231,7 @@ describe ConstantContact::Services::EventSpotService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      result = ConstantContact::Services::EventSpotService.get_event_item(1, 1)
+      result = ConstantContact::Services::EventSpotService.new(@client).get_event_item(1, 1)
       result.should be_kind_of(ConstantContact::Components::EventItem)
       result.name.should eq('Running Belt')
     end
@@ -245,7 +246,7 @@ describe ConstantContact::Services::EventSpotService do
       RestClient.stub(:post).and_return(response)
       event_item = ConstantContact::Components::EventItem.create(JSON.parse(json))
 
-      result = ConstantContact::Services::EventSpotService.add_event_item(1, event_item)
+      result = ConstantContact::Services::EventSpotService.new(@client).add_event_item(1, event_item)
       result.should be_kind_of(ConstantContact::Components::EventItem)
       result.name.should eq('Running Belt')
     end
@@ -258,7 +259,7 @@ describe ConstantContact::Services::EventSpotService do
       response = RestClient::Response.create('', net_http_resp, @request)
       RestClient.stub(:delete).and_return(response)
 
-      result = ConstantContact::Services::EventSpotService.delete_event_item(1, 1)
+      result = ConstantContact::Services::EventSpotService.new(@client).delete_event_item(1, 1)
       result.should be_true
     end
   end
@@ -272,7 +273,7 @@ describe ConstantContact::Services::EventSpotService do
       RestClient.stub(:put).and_return(response)
       event_item = ConstantContact::Components::EventItem.create(JSON.parse(json))
 
-      result = ConstantContact::Services::EventSpotService.update_event_item(1, event_item)
+      result = ConstantContact::Services::EventSpotService.new(@client).update_event_item(1, event_item)
       result.should be_kind_of(ConstantContact::Components::EventItem)
       result.name.should eq('Running Belt')
     end
@@ -286,7 +287,7 @@ describe ConstantContact::Services::EventSpotService do
       response = RestClient::Response.create(json_response, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      results = ConstantContact::Services::EventSpotService.get_event_item_attributes(1, 1)
+      results = ConstantContact::Services::EventSpotService.new(@client).get_event_item_attributes(1, 1)
       results.should be_kind_of(Array)
       results.first.should be_kind_of(ConstantContact::Components::EventItemAttribute)
       results.first.name.should eq('Royal Blue')
@@ -301,7 +302,7 @@ describe ConstantContact::Services::EventSpotService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      result = ConstantContact::Services::EventSpotService.get_event_item_attribute(1, 1, 1)
+      result = ConstantContact::Services::EventSpotService.new(@client).get_event_item_attribute(1, 1, 1)
       result.should be_kind_of(ConstantContact::Components::EventItemAttribute)
       result.name.should eq('Hi-Vis Green')
     end
@@ -316,7 +317,7 @@ describe ConstantContact::Services::EventSpotService do
       RestClient.stub(:post).and_return(response)
       event_item_attribute = ConstantContact::Components::EventItemAttribute.create(JSON.parse(json))
 
-      result = ConstantContact::Services::EventSpotService.add_event_item_attribute(1, 1, event_item_attribute)
+      result = ConstantContact::Services::EventSpotService.new(@client).add_event_item_attribute(1, 1, event_item_attribute)
       result.should be_kind_of(ConstantContact::Components::EventItemAttribute)
       result.name.should eq('Hi-Vis Green')
     end
@@ -329,7 +330,7 @@ describe ConstantContact::Services::EventSpotService do
       response = RestClient::Response.create('', net_http_resp, @request)
       RestClient.stub(:delete).and_return(response)
 
-      result = ConstantContact::Services::EventSpotService.delete_event_item_attribute(1, 1, 1)
+      result = ConstantContact::Services::EventSpotService.new(@client).delete_event_item_attribute(1, 1, 1)
       result.should be_true
     end
   end
@@ -343,7 +344,7 @@ describe ConstantContact::Services::EventSpotService do
       RestClient.stub(:put).and_return(response)
       event_item_attribute = ConstantContact::Components::EventItemAttribute.create(JSON.parse(json))
 
-      result = ConstantContact::Services::EventSpotService.update_event_item_attribute(1, 1, event_item_attribute)
+      result = ConstantContact::Services::EventSpotService.new(@client).update_event_item_attribute(1, 1, event_item_attribute)
       result.should be_kind_of(ConstantContact::Components::EventItemAttribute)
       result.name.should eq('Hi-Vis Green')
     end
@@ -357,7 +358,7 @@ describe ConstantContact::Services::EventSpotService do
       response = RestClient::Response.create(json_response, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      results = ConstantContact::Services::EventSpotService.get_promocodes(1)
+      results = ConstantContact::Services::EventSpotService.new(@client).get_promocodes(1)
       results.should be_kind_of(Array)
       results.first.should be_kind_of(ConstantContact::Components::Promocode)
       results.first.code_name.should eq('REDUCED_FEE')
@@ -372,7 +373,7 @@ describe ConstantContact::Services::EventSpotService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      result = ConstantContact::Services::EventSpotService.get_promocode(1, 1)
+      result = ConstantContact::Services::EventSpotService.new(@client).get_promocode(1, 1)
       result.should be_kind_of(ConstantContact::Components::Promocode)
       result.code_name.should eq('TOTAL_FEE')
     end
@@ -387,7 +388,7 @@ describe ConstantContact::Services::EventSpotService do
       RestClient.stub(:post).and_return(response)
       promocode = ConstantContact::Components::Promocode.create(JSON.parse(json))
 
-      result = ConstantContact::Services::EventSpotService.add_promocode(1, promocode)
+      result = ConstantContact::Services::EventSpotService.new(@client).add_promocode(1, promocode)
       result.should be_kind_of(ConstantContact::Components::Promocode)
       result.code_name.should eq('TOTAL_FEE')
     end
@@ -400,7 +401,7 @@ describe ConstantContact::Services::EventSpotService do
       response = RestClient::Response.create('', net_http_resp, @request)
       RestClient.stub(:delete).and_return(response)
 
-      result = ConstantContact::Services::EventSpotService.delete_promocode(1, 1)
+      result = ConstantContact::Services::EventSpotService.new(@client).delete_promocode(1, 1)
       result.should be_true
     end
   end
@@ -414,7 +415,7 @@ describe ConstantContact::Services::EventSpotService do
       RestClient.stub(:put).and_return(response)
       promocode = ConstantContact::Components::Promocode.create(JSON.parse(json))
 
-      result = ConstantContact::Services::EventSpotService.update_promocode(1, promocode)
+      result = ConstantContact::Services::EventSpotService.new(@client).update_promocode(1, promocode)
       result.should be_kind_of(ConstantContact::Components::Promocode)
       result.code_name.should eq('TOTAL_FEE')
     end

--- a/spec/constantcontact/services/library_service_spec.rb
+++ b/spec/constantcontact/services/library_service_spec.rb
@@ -9,6 +9,7 @@ require 'spec_helper'
 describe ConstantContact::Services::LibraryService do
   before(:each) do
     @request = double('http request', :user => nil, :password => nil, :url => 'http://example.com', :redirection_history => nil)
+    @client = ConstantContact::Api.new('explicit_api_key', "access_token")
   end
 
   describe "#get_library_info" do
@@ -19,7 +20,7 @@ describe ConstantContact::Services::LibraryService do
       response = RestClient::Response.create(json_response, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      info = ConstantContact::Services::LibraryService.get_library_info()
+      info = ConstantContact::Services::LibraryService.new(@client).get_library_info()
       info.should be_kind_of(ConstantContact::Components::LibrarySummary)
       info.usage_summary['folder_count'].should eq(6)
     end
@@ -33,7 +34,7 @@ describe ConstantContact::Services::LibraryService do
       response = RestClient::Response.create(json_response, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      folders = ConstantContact::Services::LibraryService.get_library_folders({:limit => 2})
+      folders = ConstantContact::Services::LibraryService.new(@client).get_library_folders({:limit => 2})
       folders.should be_kind_of(ConstantContact::Components::ResultSet)
       folders.results.first.should be_kind_of(ConstantContact::Components::LibraryFolder)
       folders.results.first.name.should eq('backgrounds')
@@ -49,7 +50,7 @@ describe ConstantContact::Services::LibraryService do
       RestClient.stub(:post).and_return(response)
       new_folder = ConstantContact::Components::LibraryFolder.create(JSON.parse(json))
 
-      folder = ConstantContact::Services::LibraryService.add_library_folder(new_folder)
+      folder = ConstantContact::Services::LibraryService.new(@client).add_library_folder(new_folder)
       folder.should be_kind_of(ConstantContact::Components::LibraryFolder)
       folder.name.should eq('wildflowers')
     end
@@ -63,7 +64,7 @@ describe ConstantContact::Services::LibraryService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      folder = ConstantContact::Services::LibraryService.get_library_folder(6)
+      folder = ConstantContact::Services::LibraryService.new(@client).get_library_folder(6)
       folder.should be_kind_of(ConstantContact::Components::LibraryFolder)
       folder.name.should eq('wildflowers')
     end
@@ -78,7 +79,7 @@ describe ConstantContact::Services::LibraryService do
       RestClient.stub(:put).and_return(response)
       folder = ConstantContact::Components::LibraryFolder.create(JSON.parse(json))
 
-      response = ConstantContact::Services::LibraryService.update_library_folder(folder)
+      response = ConstantContact::Services::LibraryService.new(@client).update_library_folder(folder)
       response.should be_kind_of(ConstantContact::Components::LibraryFolder)
       response.name.should eq('wildflowers')
     end
@@ -92,7 +93,7 @@ describe ConstantContact::Services::LibraryService do
       response = RestClient::Response.create('', net_http_resp, @request)
       RestClient.stub(:delete).and_return(response)
 
-      result = ConstantContact::Services::LibraryService.delete_library_folder(folder_id)
+      result = ConstantContact::Services::LibraryService.new(@client).delete_library_folder(folder_id)
       result.should be_true
     end
   end
@@ -105,7 +106,7 @@ describe ConstantContact::Services::LibraryService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      files = ConstantContact::Services::LibraryService.get_library_trash({:sort_by => 'SIZE_DESC'})
+      files = ConstantContact::Services::LibraryService.new(@client).get_library_trash({:sort_by => 'SIZE_DESC'})
       files.should be_kind_of(ConstantContact::Components::ResultSet)
       files.results.first.should be_kind_of(ConstantContact::Components::LibraryFile)
       files.results.first.name.should eq('menu_form.pdf')
@@ -119,7 +120,7 @@ describe ConstantContact::Services::LibraryService do
       response = RestClient::Response.create('', net_http_resp, @request)
       RestClient.stub(:delete).and_return(response)
 
-      result = ConstantContact::Services::LibraryService.delete_library_trash()
+      result = ConstantContact::Services::LibraryService.new(@client).delete_library_trash()
       result.should be_true
     end
   end
@@ -132,7 +133,7 @@ describe ConstantContact::Services::LibraryService do
       response = RestClient::Response.create(json_response, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      files = ConstantContact::Services::LibraryService.get_library_files({:type => 'ALL'})
+      files = ConstantContact::Services::LibraryService.new(@client).get_library_files({:type => 'ALL'})
       files.should be_kind_of(ConstantContact::Components::ResultSet)
       files.results.first.should be_kind_of(ConstantContact::Components::LibraryFile)
       files.results.first.name.should eq('IMG_0341.JPG')
@@ -148,7 +149,7 @@ describe ConstantContact::Services::LibraryService do
       response = RestClient::Response.create(json_response, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      files = ConstantContact::Services::LibraryService.get_library_files_by_folder(folder_id, {:limit => 10})
+      files = ConstantContact::Services::LibraryService.new(@client).get_library_files_by_folder(folder_id, {:limit => 10})
       files.should be_kind_of(ConstantContact::Components::ResultSet)
       files.results.first.should be_kind_of(ConstantContact::Components::LibraryFile)
       files.results.first.name.should eq('IMG_0341.JPG')
@@ -163,7 +164,7 @@ describe ConstantContact::Services::LibraryService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      file = ConstantContact::Services::LibraryService.get_library_file(6)
+      file = ConstantContact::Services::LibraryService.new(@client).get_library_file(6)
       file.should be_kind_of(ConstantContact::Components::LibraryFile)
       file.name.should eq('IMG_0261.JPG')
     end
@@ -183,7 +184,7 @@ describe ConstantContact::Services::LibraryService do
       response = RestClient::Response.create("", net_http_resp, @request)
       RestClient.stub(:post).and_return(response)
 
-      response = ConstantContact::Services::LibraryService.add_library_file(file_name, folder_id, description, source, file_type, contents)
+      response = ConstantContact::Services::LibraryService.new(@client).add_library_file(file_name, folder_id, description, source, file_type, contents)
       response.should be_kind_of(String)
       response.should eq('123456789')
     end
@@ -198,7 +199,7 @@ describe ConstantContact::Services::LibraryService do
       RestClient.stub(:put).and_return(response)
       file = ConstantContact::Components::LibraryFile.create(JSON.parse(json))
 
-      response = ConstantContact::Services::LibraryService.update_library_file(file)
+      response = ConstantContact::Services::LibraryService.new(@client).update_library_file(file)
       response.should be_kind_of(ConstantContact::Components::LibraryFile)
       response.name.should eq('IMG_0261.JPG')
     end
@@ -212,7 +213,7 @@ describe ConstantContact::Services::LibraryService do
       response = RestClient::Response.create('', net_http_resp, @request)
       RestClient.stub(:delete).and_return(response)
 
-      result = ConstantContact::Services::LibraryService.delete_library_file(file_id)
+      result = ConstantContact::Services::LibraryService.new(@client).delete_library_file(file_id)
       result.should be_true
     end
   end
@@ -226,7 +227,7 @@ describe ConstantContact::Services::LibraryService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      statuses = ConstantContact::Services::LibraryService.get_library_files_upload_status(file_id)
+      statuses = ConstantContact::Services::LibraryService.new(@client).get_library_files_upload_status(file_id)
       statuses.should be_kind_of(Array)
       statuses.first.should be_kind_of(ConstantContact::Components::UploadStatus)
       statuses.first.status.should eq('Active')
@@ -243,7 +244,7 @@ describe ConstantContact::Services::LibraryService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:put).and_return(response)
 
-      results = ConstantContact::Services::LibraryService.move_library_files(folder_id, file_id)
+      results = ConstantContact::Services::LibraryService.new(@client).move_library_files(folder_id, file_id)
       results.should be_kind_of(Array)
       results.first.should be_kind_of(ConstantContact::Components::MoveResults)
       results.first.uri.should eq('https://api.d1.constantcontact.com/v2/library/files/9')

--- a/spec/constantcontact/services/list_service_spec.rb
+++ b/spec/constantcontact/services/list_service_spec.rb
@@ -9,6 +9,7 @@ require 'spec_helper'
 describe ConstantContact::Services::ListService do
   before(:each) do
     @request = double('http request', :user => nil, :password => nil, :url => 'http://example.com', :redirection_history => nil)
+    @client = ConstantContact::Api.new('explicit_api_key', "access_token")
   end
 
   describe "#get_lists" do
@@ -19,7 +20,7 @@ describe ConstantContact::Services::ListService do
       response = RestClient::Response.create(json_response, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      lists = ConstantContact::Services::ListService.get_lists()
+      lists = ConstantContact::Services::ListService.new(@client).get_lists()
       lists.should be_kind_of(Array)
       lists.first.should be_kind_of(ConstantContact::Components::ContactList)
       lists.first.name.should eq('General Interest')
@@ -34,7 +35,7 @@ describe ConstantContact::Services::ListService do
       response = RestClient::Response.create(json, net_http_resp, @request)
       RestClient.stub(:get).and_return(response)
 
-      list = ConstantContact::Services::ListService.get_list(1)
+      list = ConstantContact::Services::ListService.new(@client).get_list(1)
       list.should be_kind_of(ConstantContact::Components::ContactList)
       list.name.should eq('Monthly Specials')
     end
@@ -49,7 +50,7 @@ describe ConstantContact::Services::ListService do
       RestClient.stub(:post).and_return(response)
       new_list = ConstantContact::Components::ContactList.create(JSON.parse(json))
 
-      list = ConstantContact::Services::ListService.add_list(new_list)
+      list = ConstantContact::Services::ListService.new(@client).add_list(new_list)
       list.should be_kind_of(ConstantContact::Components::ContactList)
       list.status.should eq('ACTIVE')
     end
@@ -64,7 +65,7 @@ describe ConstantContact::Services::ListService do
       RestClient.stub(:put).and_return(response)
       list = ConstantContact::Components::ContactList.create(JSON.parse(json))
 
-      result = ConstantContact::Services::ListService.update_list(list)
+      result = ConstantContact::Services::ListService.new(@client).update_list(list)
       result.should be_kind_of(ConstantContact::Components::ContactList)
       result.status.should eq('ACTIVE')
     end
@@ -80,7 +81,7 @@ describe ConstantContact::Services::ListService do
       RestClient.stub(:get).and_return(response)
       list = ConstantContact::Components::ContactList.create(JSON.parse(json_list))
 
-      contacts = ConstantContact::Services::ListService.get_contacts_from_list(list)
+      contacts = ConstantContact::Services::ListService.new(@client).get_contacts_from_list(list)
       contacts.should be_kind_of(ConstantContact::Components::ResultSet)
       contacts.results.first.should be_kind_of(ConstantContact::Components::Contact)
       contacts.results.first.fax.should eq('318-978-7575')


### PR DESCRIPTION
I made `api_key` and `access_token` instance variables of `ConstantContact::Api`, instead of global variables. Also updated the services so that they are instantiated, and take an instance of `ConstantContact::Api` so they can read the api key and token. 

Alternative solution: It would've also been possible to update every method in every service to take the api key and token as arguments, but this seemed slightly easier. 

Hopefully this resolves the race conditions we are seeing under high concurrency.